### PR TITLE
Properly highlight tags with dashes in their name

### DIFF
--- a/vue.YAML-tmLanguage
+++ b/vue.YAML-tmLanguage
@@ -7,7 +7,7 @@ uuid: 5512c10d-4cc5-434c-b8fc-53b912f55ab3
 
 patterns:
 - name: meta.tag.any.html
-  begin: (<)([a-zA-Z0-9:]++)(?=[^>]*></\2>)
+  begin: (<)([a-zA-Z0-9:-]++)(?=[^>]*></\2>)
   beginCaptures:
     '1': {name: punctuation.definition.tag.begin.html}
     '2': {name: entity.name.tag.html}
@@ -220,7 +220,7 @@ patterns:
   - include: '#tag-stuff'
 
 - name: meta.tag.other.html
-  begin: (</?)([a-zA-Z0-9:]+)
+  begin: (</?)([a-zA-Z0-9:-]+)
   beginCaptures:
     '1': {name: punctuation.definition.tag.begin.html}
     '2': {name: entity.name.tag.other.html}

--- a/vue.tmLanguage
+++ b/vue.tmLanguage
@@ -34,7 +34,7 @@
 	<array>
 		<dict>
 			<key>begin</key>
-			<string>(&lt;)([a-zA-Z0-9:]++)(?=[^&gt;]*&gt;&lt;/\2&gt;)</string>
+			<string>(&lt;)([a-zA-Z0-9:-]++)(?=[^&gt;]*&gt;&lt;/\2&gt;)</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>
@@ -741,7 +741,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>(&lt;/?)([a-zA-Z0-9:]+)</string>
+			<string>(&lt;/?)([a-zA-Z0-9:-]+)</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>


### PR DESCRIPTION
The web components spec allows for dashes in tag names and the vuejs
community seems to prefer kebab naming for tag names.

This change allows sublime to properly highlight tags with dashes in
their name.