### PR TITLE
Use sublime stylus plugin for embedded stylus code

### DIFF
--- a/vue.YAML-tmLanguage
+++ b/vue.YAML-tmLanguage
@@ -77,7 +77,7 @@ patterns:
     patterns:
     - include: text.jade
 
-- name: source.vue-stylus.embedded.html
+- name: source.stylus.embedded.html
   begin: (?:^\s+)?(<)((?i:style))\b(?=[^>]*lang="stylus(?:\?[^"]*)?")
   end: (</)((?i:style))(>)(?:\s*\n)?
   captures:

--- a/vue.tmLanguage
+++ b/vue.tmLanguage
@@ -285,7 +285,7 @@
 			<key>end</key>
 			<string>(&lt;/)((?i:style))(&gt;)(?:\s*\n)?</string>
 			<key>name</key>
-			<string>source.vue-stylus.embedded.html</string>
+			<string>source.stylus.embedded.html</string>
 			<key>patterns</key>
 			<array>
 				<dict>


### PR DESCRIPTION
Stylus needs slashy comments, like this:
`
  //  font-family 'Roboto', 'Helvetica', sans-serif
`

The old files made sublime produce html comments, like this:

`  <!-- font-family 'Roboto', 'Helvetica', sans-serif -->
`

It looks like those file patterns somehow match to the regular stylus plugin for sublime. The way it was, sublime looked for a a plugin called vue-stylus, which doesn't exist, so it reverted to using html comments.

This only affected the comments. The syntax highlighting was still working fine. But the stylus plugin is definitely required for both the highlighting and commenting to work.