### PR TITLE
Add support for type="text/babel"

### DIFF
--- a/vue.YAML-tmLanguage
+++ b/vue.YAML-tmLanguage
@@ -195,7 +195,7 @@ patterns:
     - include: source.coffee
 
 - name: source.js.embedded.html
-  begin: (<)((?i:script))\b(?![^>]*/>)(?![^>]*(?i:type.?=.?text/((?!javascript).*)))
+  begin: (<)((?i:script))\b(?![^>]*/>)(?![^>]*(?i:type.?=.?text/((?!javascript|babel).*)))
   beginCaptures:
     '1': {name: punctuation.definition.tag.begin.html}
     '2': {name: entity.name.tag.script.html}

--- a/vue.tmLanguage
+++ b/vue.tmLanguage
@@ -651,7 +651,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>(&lt;)((?i:script))\b(?![^&gt;]*/&gt;)(?![^&gt;]*(?i:type.?=.?text/((?!javascript).*)))</string>
+			<string>(&lt;)((?i:script))\b(?![^&gt;]*/&gt;)(?![^&gt;]*(?i:type.?=.?text/((?!javascript|babel).*)))</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>


### PR DESCRIPTION
Currently `<script type="text/babel">` is the only way to get bug-free syntax highlighting of ES6 in `*.vue` files in PHPStorm, but once the code is pushed to GitHub, the highlighting is lost.