### PR TITLE
added slm template syntax

### DIFF
--- a/vue.YAML-tmLanguage
+++ b/vue.YAML-tmLanguage
@@ -63,6 +63,22 @@ patterns:
   - name: invalid.illegal.bad-comments-or-CDATA.html
     match: (\s*)(?!--|>)\S(\s*)
 
+- name: text.slm.embedded.html
+  begin: (?:^\s+)?(<)((?i:template))\b(?=[^>]*lang="slm(?:\?[^"]*)?")
+  end: (</)((?i:template))(>)(?:\s*\n)?
+  captures:
+    '1': {name: punctuation.definition.tag.begin.html}
+    '2': {name: entity.name.tag.style.html}
+    '3': {name: punctuation.definition.tag.html}
+  patterns:
+  - include: '#tag-stuff'
+  - begin: (>)
+    beginCaptures:
+      '1': {name: punctuation.definition.tag.end.html}
+    end: (?=</(?i:template))
+    patterns:
+    - include: text.slm
+
 - name: text.jade.embedded.html
   begin: (?:^\s+)?(<)((?i:template))\b(?=[^>]*lang="jade(?:\?[^"]*)?")
   end: (</)((?i:template))(>)(?:\s*\n)?

--- a/vue.tmLanguage
+++ b/vue.tmLanguage
@@ -211,6 +211,60 @@
 		</dict>
 		<dict>
 			<key>begin</key>
+			<string>(?:^\s+)?(&lt;)((?i:template))\b(?=[^&gt;]*lang="slm(?:\?[^"]*)?")</string>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.tag.begin.html</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>entity.name.tag.style.html</string>
+				</dict>
+				<key>3</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.tag.html</string>
+				</dict>
+			</dict>
+			<key>end</key>
+			<string>(&lt;/)((?i:template))(&gt;)(?:\s*\n)?</string>
+			<key>name</key>
+			<string>text.slm.embedded.html</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>#tag-stuff</string>
+				</dict>
+				<dict>
+					<key>begin</key>
+					<string>(&gt;)</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.tag.end.html</string>
+						</dict>
+					</dict>
+					<key>end</key>
+					<string>(?=&lt;/(?i:template))</string>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>include</key>
+							<string>text.slm</string>
+						</dict>
+					</array>
+				</dict>
+			</array>
+		</dict>
+		<dict>
+			<key>begin</key>
 			<string>(?:^\s+)?(&lt;)((?i:template))\b(?=[^&gt;]*lang="jade(?:\?[^"]*)?")</string>
 			<key>captures</key>
 			<dict>


### PR DESCRIPTION
Added highlight for [slm template syntax](https://github.com/slm-lang/slm).

It is *very* similar to Jade/Pug with the small (perhaps very small), advantage of allowing the usage of the `v-bind:` shortcut which is an error in Jade.

Also you need to install `slm-loader` and use webpack with :

```js
    vue: {
        loaders: {
           //....
            slm: "vue-html-loader!slm",
        },
    },
```