### PR TITLE
add wpy extension

### DIFF
--- a/vue.sublime-settings
+++ b/vue.sublime-settings
@@ -2,6 +2,7 @@
 	"extensions":
 	[
 		"vue",
-    "we"
+                "we",
+		"wpy"
 	]
 }


### PR DESCRIPTION
希望添加wpy后缀支持。
wpy为wepyjs的后缀名。
wepyjs 与 vue语法基于一致，用于微信小程序开发。
参考repo: https://github.com/wepyjs/wepy