### PR TITLE
Add support for single quotes for embedded languages

### DIFF
--- a/vue.YAML-tmLanguage
+++ b/vue.YAML-tmLanguage
@@ -64,7 +64,7 @@ patterns:
     match: (\s*)(?!--|>)\S(\s*)
 
 - name: text.slm.embedded.html
-  begin: (?:^\s+)?(<)((?i:template))\b(?=[^>]*lang="slm(?:\?[^"]*)?")
+  begin: (?:^\s+)?(<)((?i:template))\b(?=[^>]*lang=['"]slm(?:\?[^"]*)?['"])
   end: (</)((?i:template))(>)(?:\s*\n)?
   captures:
     '1': {name: punctuation.definition.tag.begin.html}
@@ -80,7 +80,7 @@ patterns:
     - include: text.slm
 
 - name: text.jade.embedded.html
-  begin: (?:^\s+)?(<)((?i:template))\b(?=[^>]*lang="jade(?:\?[^"]*)?")
+  begin: (?:^\s+)?(<)((?i:template))\b(?=[^>]*lang=['"]jade(?:\?[^"]*)?['"])
   end: (</)((?i:template))(>)(?:\s*\n)?
   captures:
     '1': {name: punctuation.definition.tag.begin.html}
@@ -96,7 +96,7 @@ patterns:
     - include: text.jade
 
 - name: text.pug.embedded.html
-  begin: (?:^\s+)?(<)((?i:template))\b(?=[^>]*lang="pug(?:\?[^"]*)?")
+  begin: (?:^\s+)?(<)((?i:template))\b(?=[^>]*lang=['"]pug(?:\?[^"]*)?['"])
   end: (</)((?i:template))(>)(?:\s*\n)?
   captures:
     '1': {name: punctuation.definition.tag.begin.html}
@@ -113,7 +113,7 @@ patterns:
 
 
 - name: source.stylus.embedded.html
-  begin: (?:^\s+)?(<)((?i:style))\b(?=[^>]*lang="stylus(?:\?[^"]*)?")
+  begin: (?:^\s+)?(<)((?i:style))\b(?=[^>]*lang=['"]stylus(?:\?[^"]*)?['"])
   end: (</)((?i:style))(>)(?:\s*\n)?
   captures:
     '1': {name: punctuation.definition.tag.begin.html}
@@ -129,7 +129,7 @@ patterns:
     - include: source.stylus
 
 - name: source.postcss.embedded.html
-  begin: (?:^\s+)?(<)((?i:style))\b(?=[^>]*lang="postcss(?:\?[^"]*)?")
+  begin: (?:^\s+)?(<)((?i:style))\b(?=[^>]*lang=['"]postcss(?:\?[^"]*)?['"])
   end: (</)((?i:style))(>)(?:\s*\n)?
   captures:
     '1': {name: punctuation.definition.tag.begin.html}
@@ -145,7 +145,7 @@ patterns:
     - include: source.postcss
 
 - name: source.sass.embedded.html
-  begin: (?:^\s+)?(<)((?i:style))\b(?=[^>]*lang="(?:sass)(?:\?[^"]*)?")
+  begin: (?:^\s+)?(<)((?i:style))\b(?=[^>]*lang=['"](?:sass)(?:\?[^"]*)?['"])
   end: (</)((?i:style))(>)(?:\s*\n)?
   captures:
     '1': {name: punctuation.definition.tag.begin.html}
@@ -162,7 +162,7 @@ patterns:
     - include: source.scss
 
 - name: source.scss.embedded.html
-  begin: (?:^\s+)?(<)((?i:style))\b(?=[^>]*lang="(?:scss)(?:\?[^"]*)?")
+  begin: (?:^\s+)?(<)((?i:style))\b(?=[^>]*lang=['"](?:scss)(?:\?[^"]*)?['"])
   end: (</)((?i:style))(>)(?:\s*\n)?
   captures:
     '1': {name: punctuation.definition.tag.begin.html}
@@ -180,7 +180,7 @@ patterns:
 
 
 - name: source.less.embedded.html
-  begin: (?:^\s+)?(<)((?i:style))\b(?=[^>]*lang="less(?:\?[^"]*)?")
+  begin: (?:^\s+)?(<)((?i:style))\b(?=[^>]*lang=['"]less(?:\?[^"]*)?['"])
   end: (</)((?i:style))(>)(?:\s*\n)?
   captures:
     '1': {name: punctuation.definition.tag.begin.html}
@@ -212,7 +212,7 @@ patterns:
     - include: source.css
 
 - name: source.coffee.embedded.html
-  begin: (?:^\s+)?(<)((?i:script))\b(?=[^>]*lang="coffee(?:\?[^"]*)?")
+  begin: (?:^\s+)?(<)((?i:script))\b(?=[^>]*lang=['"]coffee(?:\?[^"]*)?['"])
   beginCaptures:
     '1': {name: punctuation.definition.tag.begin.html}
     '2': {name: entity.name.tag.script.html}
@@ -230,7 +230,7 @@ patterns:
     - include: source.coffee
 
 - name: source.livescript.embedded.html
-  begin: (?:^\s+)?(<)((?i:script))\b(?=[^>]*lang="livescript(?:\?[^"]*)?")
+  begin: (?:^\s+)?(<)((?i:script))\b(?=[^>]*lang=['"]livescript(?:\?[^"]*)?['"])
   beginCaptures:
     '1': {name: punctuation.definition.tag.begin.html}
     '2': {name: entity.name.tag.script.html}

--- a/vue.sublime-settings
+++ b/vue.sublime-settings
@@ -2,7 +2,7 @@
 	"extensions":
 	[
 		"vue",
-    "we",
+		"we",
 		"wpy"
 	]
 }

--- a/vue.sublime-settings
+++ b/vue.sublime-settings
@@ -2,7 +2,7 @@
 	"extensions":
 	[
 		"vue",
-                "we",
+    "we",
 		"wpy"
 	]
 }

--- a/vue.tmLanguage
+++ b/vue.tmLanguage
@@ -211,7 +211,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>(?:^\s+)?(&lt;)((?i:template))\b(?=[^&gt;]*lang="slm(?:\?[^"]*)?")</string>
+			<string>(?:^\s+)?(&lt;)((?i:template))\b(?=[^&gt;]*lang=['"]slm(?:\?[^"]*)?['"])</string>
 			<key>captures</key>
 			<dict>
 				<key>1</key>
@@ -265,7 +265,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>(?:^\s+)?(&lt;)((?i:template))\b(?=[^&gt;]*lang="jade(?:\?[^"]*)?")</string>
+			<string>(?:^\s+)?(&lt;)((?i:template))\b(?=[^&gt;]*lang=['"]jade(?:\?[^"]*)?['"])</string>
 			<key>captures</key>
 			<dict>
 				<key>1</key>
@@ -319,7 +319,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>(?:^\s+)?(&lt;)((?i:template))\b(?=[^&gt;]*lang="pug(?:\?[^"]*)?")</string>
+			<string>(?:^\s+)?(&lt;)((?i:template))\b(?=[^&gt;]*lang=['"]pug(?:\?[^"]*)?['"])</string>
 			<key>captures</key>
 			<dict>
 				<key>1</key>
@@ -373,7 +373,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>(?:^\s+)?(&lt;)((?i:style))\b(?=[^&gt;]*lang="stylus(?:\?[^"]*)?")</string>
+			<string>(?:^\s+)?(&lt;)((?i:style))\b(?=[^&gt;]*lang=['"]stylus(?:\?[^"]*)?['"])</string>
 			<key>captures</key>
 			<dict>
 				<key>1</key>
@@ -427,7 +427,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>(?:^\s+)?(&lt;)((?i:style))\b(?=[^&gt;]*lang="postcss(?:\?[^"]*)?")</string>
+			<string>(?:^\s+)?(&lt;)((?i:style))\b(?=[^&gt;]*lang=['"]postcss(?:\?[^"]*)?['"])</string>
 			<key>captures</key>
 			<dict>
 				<key>1</key>
@@ -481,7 +481,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>(?:^\s+)?(&lt;)((?i:style))\b(?=[^&gt;]*lang="(?:sass)(?:\?[^"]*)?")</string>
+			<string>(?:^\s+)?(&lt;)((?i:style))\b(?=[^&gt;]*lang=['"](?:sass)(?:\?[^"]*)?['"])</string>
 			<key>captures</key>
 			<dict>
 				<key>1</key>
@@ -539,7 +539,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>(?:^\s+)?(&lt;)((?i:style))\b(?=[^&gt;]*lang="(?:scss)(?:\?[^"]*)?")</string>
+			<string>(?:^\s+)?(&lt;)((?i:style))\b(?=[^&gt;]*lang=['"](?:scss)(?:\?[^"]*)?['"])</string>
 			<key>captures</key>
 			<dict>
 				<key>1</key>
@@ -597,7 +597,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>(?:^\s+)?(&lt;)((?i:style))\b(?=[^&gt;]*lang="less(?:\?[^"]*)?")</string>
+			<string>(?:^\s+)?(&lt;)((?i:style))\b(?=[^&gt;]*lang=['"]less(?:\?[^"]*)?['"])</string>
 			<key>captures</key>
 			<dict>
 				<key>1</key>
@@ -705,7 +705,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>(?:^\s+)?(&lt;)((?i:script))\b(?=[^&gt;]*lang="coffee(?:\?[^"]*)?")</string>
+			<string>(?:^\s+)?(&lt;)((?i:script))\b(?=[^&gt;]*lang=['"]coffee(?:\?[^"]*)?['"])</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>
@@ -767,7 +767,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>(?:^\s+)?(&lt;)((?i:script))\b(?=[^&gt;]*lang="livescript(?:\?[^"]*)?")</string>
+			<string>(?:^\s+)?(&lt;)((?i:script))\b(?=[^&gt;]*lang=['"]livescript(?:\?[^"]*)?['"])</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>


### PR DESCRIPTION
This adds support for adding embedded languages with single quotes.

Previously you could only do: `<template lang="pug">`
Now, you can do: `<template lang='pug'>` as well.

This problem was referenced in #56.