### PR TITLE
Prevent mixing single & double quotes

### DIFF
--- a/vue.YAML-tmLanguage
+++ b/vue.YAML-tmLanguage
@@ -248,7 +248,7 @@ patterns:
     - include: source.livescript
 
 - name: source.js.embedded.html
-  begin: (?:^\s+)?(<)((?i:script))\b(?=[^>]*type=(['"])text\/(babel|javascript)\1?)
+  begin: (<)((?:script))\b(?![^>]*/>)(?![^>]*(?i:type.?=.?text/((?!javascript|babel).*)))
   beginCaptures:
     '1': {name: punctuation.definition.tag.begin.html}
     '2': {name: entity.name.tag.script.html}
@@ -466,4 +466,5 @@ foldingStopMarker: |-
   |\{\{?/(if|foreach|capture|literal|foreach|php|section|strip)
   |^[^{]*\}
   )
+
 keyEquivalent: ^~H

--- a/vue.YAML-tmLanguage
+++ b/vue.YAML-tmLanguage
@@ -64,7 +64,7 @@ patterns:
     match: (\s*)(?!--|>)\S(\s*)
 
 - name: text.slm.embedded.html
-  begin: (?:^\s+)?(<)((?i:template))\b(?=[^>]*lang=(['"])slm\1?")
+  begin: (?:^\s+)?(<)((?i:template))\b(?=[^>]*lang=(['"])slm\1?)
   end: (</)((?i:template))(>)(?:\s*\n)?
   captures:
     '1': {name: punctuation.definition.tag.begin.html}
@@ -80,7 +80,7 @@ patterns:
     - include: text.slm
 
 - name: text.jade.embedded.html
-  begin: (?:^\s+)?(<)((?i:template))\b(?=[^>]*lang=(['"])jade\1?")
+  begin: (?:^\s+)?(<)((?i:template))\b(?=[^>]*lang=(['"])jade\1?)
   end: (</)((?i:template))(>)(?:\s*\n)?
   captures:
     '1': {name: punctuation.definition.tag.begin.html}
@@ -96,7 +96,7 @@ patterns:
     - include: text.jade
 
 - name: text.pug.embedded.html
-  begin: (?:^\s+)?(<)((?i:template))\b(?=[^>]*lang=(['"])pug\1?")
+  begin: (?:^\s+)?(<)((?i:template))\b(?=[^>]*lang=(['"])pug\1?)
   end: (</)((?i:template))(>)(?:\s*\n)?
   captures:
     '1': {name: punctuation.definition.tag.begin.html}
@@ -113,7 +113,7 @@ patterns:
 
 
 - name: source.stylus.embedded.html
-  begin: (?:^\s+)?(<)((?i:style))\b(?=[^>]*lang=(['"])stylus\1?")
+  begin: (?:^\s+)?(<)((?i:style))\b(?=[^>]*lang=(['"])stylus\1?)
   end: (</)((?i:style))(>)(?:\s*\n)?
   captures:
     '1': {name: punctuation.definition.tag.begin.html}
@@ -129,7 +129,7 @@ patterns:
     - include: source.stylus
 
 - name: source.postcss.embedded.html
-  begin: (?:^\s+)?(<)((?i:style))\b(?=[^>]*lang=(['"])postcss\1?")
+  begin: (?:^\s+)?(<)((?i:style))\b(?=[^>]*lang=(['"])postcss\1?)
   end: (</)((?i:style))(>)(?:\s*\n)?
   captures:
     '1': {name: punctuation.definition.tag.begin.html}
@@ -145,7 +145,7 @@ patterns:
     - include: source.postcss
 
 - name: source.sass.embedded.html
-  begin: (?:^\s+)?(<)((?i:style))\b(?=[^>]*lang=(['"])sass\1?")
+  begin: (?:^\s+)?(<)((?i:style))\b(?=[^>]*lang=(['"])sass\1?)
   end: (</)((?i:style))(>)(?:\s*\n)?
   captures:
     '1': {name: punctuation.definition.tag.begin.html}
@@ -162,7 +162,7 @@ patterns:
     - include: source.scss
 
 - name: source.scss.embedded.html
-  begin: (?:^\s+)?(<)((?i:style))\b(?=[^>]*lang=(['"])scss\1?")
+  begin: (?:^\s+)?(<)((?i:style))\b(?=[^>]*lang=(['"])scss\1?)
   end: (</)((?i:style))(>)(?:\s*\n)?
   captures:
     '1': {name: punctuation.definition.tag.begin.html}
@@ -180,7 +180,7 @@ patterns:
 
 
 - name: source.less.embedded.html
-  begin: (?:^\s+)?(<)((?i:style))\b(?=[^>]*lang=(['"])less\1?")
+  begin: (?:^\s+)?(<)((?i:style))\b(?=[^>]*lang=(['"])less\1?)
   end: (</)((?i:style))(>)(?:\s*\n)?
   captures:
     '1': {name: punctuation.definition.tag.begin.html}
@@ -212,7 +212,7 @@ patterns:
     - include: source.css
 
 - name: source.coffee.embedded.html
-  begin: (?:^\s+)?(<)((?i:script))\b(?=[^>]*lang=(['"])coffee\1?")
+  begin: (?:^\s+)?(<)((?i:script))\b(?=[^>]*lang=(['"])coffee\1?)
   beginCaptures:
     '1': {name: punctuation.definition.tag.begin.html}
     '2': {name: entity.name.tag.script.html}
@@ -230,7 +230,7 @@ patterns:
     - include: source.coffee
 
 - name: source.livescript.embedded.html
-  begin: (?:^\s+)?(<)((?i:script))\b(?=[^>]*lang=(['"])livescript\1?")
+  begin: (?:^\s+)?(<)((?i:script))\b(?=[^>]*lang=(['"])livescript\1?)
   beginCaptures:
     '1': {name: punctuation.definition.tag.begin.html}
     '2': {name: entity.name.tag.script.html}
@@ -248,7 +248,7 @@ patterns:
     - include: source.livescript
 
 - name: source.js.embedded.html
-  begin: (?:^\s+)?(<)((?i:script))\b(?=[^>]*type=(['"])text\/(babel|javascript)\1?")
+  begin: (?:^\s+)?(<)((?i:script))\b(?=[^>]*type=(['"])text\/(babel|javascript)\1?)
   beginCaptures:
     '1': {name: punctuation.definition.tag.begin.html}
     '2': {name: entity.name.tag.script.html}
@@ -466,5 +466,4 @@ foldingStopMarker: |-
   |\{\{?/(if|foreach|capture|literal|foreach|php|section|strip)
   |^[^{]*\}
   )
-
 keyEquivalent: ^~H

--- a/vue.YAML-tmLanguage
+++ b/vue.YAML-tmLanguage
@@ -248,7 +248,7 @@ patterns:
     - include: source.livescript
 
 - name: source.js.embedded.html
-  begin: (<)((?:script))\b(?![^>]*/>)(?![^>]*(?i:type.?=.?text/((?!javascript|babel).*)))
+  begin: (<)((?i:script))\b(?![^>]*/>)(?![^>]*(?i:type.?=.?text/((?!javascript|babel).*)))
   beginCaptures:
     '1': {name: punctuation.definition.tag.begin.html}
     '2': {name: entity.name.tag.script.html}

--- a/vue.YAML-tmLanguage
+++ b/vue.YAML-tmLanguage
@@ -64,7 +64,7 @@ patterns:
     match: (\s*)(?!--|>)\S(\s*)
 
 - name: text.slm.embedded.html
-  begin: (?:^\s+)?(<)((?i:template))\b(?=[^>]*lang="slm(?:\?[^"]*)?")
+  begin: (?:^\s+)?(<)((?i:template))\b(?=[^>]*lang=(['"])slm\1?")
   end: (</)((?i:template))(>)(?:\s*\n)?
   captures:
     '1': {name: punctuation.definition.tag.begin.html}
@@ -80,7 +80,7 @@ patterns:
     - include: text.slm
 
 - name: text.jade.embedded.html
-  begin: (?:^\s+)?(<)((?i:template))\b(?=[^>]*lang="jade(?:\?[^"]*)?")
+  begin: (?:^\s+)?(<)((?i:template))\b(?=[^>]*lang=(['"])jade\1?")
   end: (</)((?i:template))(>)(?:\s*\n)?
   captures:
     '1': {name: punctuation.definition.tag.begin.html}
@@ -96,7 +96,7 @@ patterns:
     - include: text.jade
 
 - name: text.pug.embedded.html
-  begin: (?:^\s+)?(<)((?i:template))\b(?=[^>]*lang="pug(?:\?[^"]*)?")
+  begin: (?:^\s+)?(<)((?i:template))\b(?=[^>]*lang=(['"])pug\1?")
   end: (</)((?i:template))(>)(?:\s*\n)?
   captures:
     '1': {name: punctuation.definition.tag.begin.html}
@@ -113,7 +113,7 @@ patterns:
 
 
 - name: source.stylus.embedded.html
-  begin: (?:^\s+)?(<)((?i:style))\b(?=[^>]*lang="stylus(?:\?[^"]*)?")
+  begin: (?:^\s+)?(<)((?i:style))\b(?=[^>]*lang=(['"])stylus\1?")
   end: (</)((?i:style))(>)(?:\s*\n)?
   captures:
     '1': {name: punctuation.definition.tag.begin.html}
@@ -129,7 +129,7 @@ patterns:
     - include: source.stylus
 
 - name: source.postcss.embedded.html
-  begin: (?:^\s+)?(<)((?i:style))\b(?=[^>]*lang="postcss(?:\?[^"]*)?")
+  begin: (?:^\s+)?(<)((?i:style))\b(?=[^>]*lang=(['"])postcss\1?")
   end: (</)((?i:style))(>)(?:\s*\n)?
   captures:
     '1': {name: punctuation.definition.tag.begin.html}
@@ -145,7 +145,7 @@ patterns:
     - include: source.postcss
 
 - name: source.sass.embedded.html
-  begin: (?:^\s+)?(<)((?i:style))\b(?=[^>]*lang="(?:sass)(?:\?[^"]*)?")
+  begin: (?:^\s+)?(<)((?i:style))\b(?=[^>]*lang=(['"])sass\1?")
   end: (</)((?i:style))(>)(?:\s*\n)?
   captures:
     '1': {name: punctuation.definition.tag.begin.html}
@@ -162,7 +162,7 @@ patterns:
     - include: source.scss
 
 - name: source.scss.embedded.html
-  begin: (?:^\s+)?(<)((?i:style))\b(?=[^>]*lang="(?:scss)(?:\?[^"]*)?")
+  begin: (?:^\s+)?(<)((?i:style))\b(?=[^>]*lang=(['"])scss\1?")
   end: (</)((?i:style))(>)(?:\s*\n)?
   captures:
     '1': {name: punctuation.definition.tag.begin.html}
@@ -180,7 +180,7 @@ patterns:
 
 
 - name: source.less.embedded.html
-  begin: (?:^\s+)?(<)((?i:style))\b(?=[^>]*lang="less(?:\?[^"]*)?")
+  begin: (?:^\s+)?(<)((?i:style))\b(?=[^>]*lang=(['"])less\1?")
   end: (</)((?i:style))(>)(?:\s*\n)?
   captures:
     '1': {name: punctuation.definition.tag.begin.html}
@@ -212,7 +212,7 @@ patterns:
     - include: source.css
 
 - name: source.coffee.embedded.html
-  begin: (?:^\s+)?(<)((?i:script))\b(?=[^>]*lang="coffee(?:\?[^"]*)?")
+  begin: (?:^\s+)?(<)((?i:script))\b(?=[^>]*lang=(['"])coffee\1?")
   beginCaptures:
     '1': {name: punctuation.definition.tag.begin.html}
     '2': {name: entity.name.tag.script.html}
@@ -230,7 +230,7 @@ patterns:
     - include: source.coffee
 
 - name: source.livescript.embedded.html
-  begin: (?:^\s+)?(<)((?i:script))\b(?=[^>]*lang="livescript(?:\?[^"]*)?")
+  begin: (?:^\s+)?(<)((?i:script))\b(?=[^>]*lang=(['"])livescript\1?")
   beginCaptures:
     '1': {name: punctuation.definition.tag.begin.html}
     '2': {name: entity.name.tag.script.html}
@@ -248,7 +248,7 @@ patterns:
     - include: source.livescript
 
 - name: source.js.embedded.html
-  begin: (<)((?i:script))\b(?![^>]*/>)(?![^>]*(?i:type.?=.?text/((?!javascript|babel).*)))
+  begin: (?:^\s+)?(<)((?i:script))\b(?=[^>]*type=(['"])text\/(babel|javascript)\1?")
   beginCaptures:
     '1': {name: punctuation.definition.tag.begin.html}
     '2': {name: entity.name.tag.script.html}

--- a/vue.tmLanguage
+++ b/vue.tmLanguage
@@ -211,7 +211,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>(?:^\s+)?(&lt;)((?i:template))\b(?=[^&gt;]*lang="slm(?:\?[^"]*)?")</string>
+			<string>(?:^\s+)?(&lt;)((?i:template))\b(?=[^&gt;]*lang=(['"])slm\1?)</string>
 			<key>captures</key>
 			<dict>
 				<key>1</key>
@@ -265,7 +265,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>(?:^\s+)?(&lt;)((?i:template))\b(?=[^&gt;]*lang="jade(?:\?[^"]*)?")</string>
+			<string>(?:^\s+)?(&lt;)((?i:template))\b(?=[^&gt;]*lang=(['"])jade\1?)</string>
 			<key>captures</key>
 			<dict>
 				<key>1</key>
@@ -319,7 +319,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>(?:^\s+)?(&lt;)((?i:template))\b(?=[^&gt;]*lang="pug(?:\?[^"]*)?")</string>
+			<string>(?:^\s+)?(&lt;)((?i:template))\b(?=[^&gt;]*lang=(['"])pug\1?)</string>
 			<key>captures</key>
 			<dict>
 				<key>1</key>
@@ -373,7 +373,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>(?:^\s+)?(&lt;)((?i:style))\b(?=[^&gt;]*lang="stylus(?:\?[^"]*)?")</string>
+			<string>(?:^\s+)?(&lt;)((?i:style))\b(?=[^&gt;]*lang=(['"])stylus\1?)</string>
 			<key>captures</key>
 			<dict>
 				<key>1</key>
@@ -427,7 +427,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>(?:^\s+)?(&lt;)((?i:style))\b(?=[^&gt;]*lang="postcss(?:\?[^"]*)?")</string>
+			<string>(?:^\s+)?(&lt;)((?i:style))\b(?=[^&gt;]*lang=(['"])postcss\1?)</string>
 			<key>captures</key>
 			<dict>
 				<key>1</key>
@@ -481,7 +481,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>(?:^\s+)?(&lt;)((?i:style))\b(?=[^&gt;]*lang="(?:sass)(?:\?[^"]*)?")</string>
+			<string>(?:^\s+)?(&lt;)((?i:style))\b(?=[^&gt;]*lang=(['"])sass\1?)</string>
 			<key>captures</key>
 			<dict>
 				<key>1</key>
@@ -539,7 +539,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>(?:^\s+)?(&lt;)((?i:style))\b(?=[^&gt;]*lang="(?:scss)(?:\?[^"]*)?")</string>
+			<string>(?:^\s+)?(&lt;)((?i:style))\b(?=[^&gt;]*lang=(['"])scss\1?)</string>
 			<key>captures</key>
 			<dict>
 				<key>1</key>
@@ -597,7 +597,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>(?:^\s+)?(&lt;)((?i:style))\b(?=[^&gt;]*lang="less(?:\?[^"]*)?")</string>
+			<string>(?:^\s+)?(&lt;)((?i:style))\b(?=[^&gt;]*lang=(['"])less\1?)</string>
 			<key>captures</key>
 			<dict>
 				<key>1</key>
@@ -705,7 +705,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>(?:^\s+)?(&lt;)((?i:script))\b(?=[^&gt;]*lang="coffee(?:\?[^"]*)?")</string>
+			<string>(?:^\s+)?(&lt;)((?i:script))\b(?=[^&gt;]*lang=(['"])coffee\1?)</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>
@@ -767,7 +767,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>(?:^\s+)?(&lt;)((?i:script))\b(?=[^&gt;]*lang="livescript(?:\?[^"]*)?")</string>
+			<string>(?:^\s+)?(&lt;)((?i:script))\b(?=[^&gt;]*lang=(['"])livescript\1?)</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>
@@ -829,7 +829,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>(&lt;)((?i:script))\b(?![^&gt;]*/&gt;)(?![^&gt;]*(?i:type.?=.?text/((?!javascript|babel).*)))</string>
+			<string>(&lt;)((?:script))\b(?![^&gt;]*/&gt;)(?![^&gt;]*(?i:type.?=.?text/((?!javascript|babel).*)))</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>

--- a/vue.tmLanguage
+++ b/vue.tmLanguage
@@ -829,7 +829,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>(&lt;)((?:script))\b(?![^&gt;]*/&gt;)(?![^&gt;]*(?i:type.?=.?text/((?!javascript|babel).*)))</string>
+			<string>(&lt;)((?i:script))\b(?![^&gt;]*/&gt;)(?![^&gt;]*(?i:type.?=.?text/((?!javascript|babel).*)))</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>


### PR DESCRIPTION
Fixes #56 #82

07d75b8bfd1ad5a13da7827f65b45dd446cae830 finally added support for single quotes. However it allows mixing single and double quotes. 

This changes the queries to only matches a closing `"` if it was opened by a `"` and vice-versa.