### PR TITLE
Highlighting bug fixes

### DIFF
--- a/Vue Component.sublime-syntax
+++ b/Vue Component.sublime-syntax
@@ -696,7 +696,7 @@ contexts:
         - match: (>)
           captures:
             1: meta.tag.style.begin.html punctuation.definition.tag.end.html
-          embed: scope:source.scss
+          embed: scope:source.sass
           escape: (?i)(?=</style)
         - match: ''
           push:

--- a/Vue Component.sublime-syntax
+++ b/Vue Component.sublime-syntax
@@ -696,7 +696,7 @@ contexts:
         - match: (>)
           captures:
             1: meta.tag.style.begin.html punctuation.definition.tag.end.html
-          embed: scope:source.sass
+          embed: scope:source.scss
           escape: (?i)(?=</style)
         - match: ''
           push:

--- a/Vue Component.sublime-syntax
+++ b/Vue Component.sublime-syntax
@@ -516,10 +516,10 @@ contexts:
     - include: main
 
   vue-directive:
-    - match: \b(v-[.|:|\w-]+)\b
+    - match: \b(v-[\w-]+)\b
       scope: entity.other.attribute-name.html
       push: js-attribute-value
-    - match: \B(:|@)([.|\w-]+)\b
+    - match: \B(:|@)([\w-]+)\b
       captures:
         1: punctuation.definition.attribute.html
         2: entity.other.attribute-name.html

--- a/Vue Component.sublime-syntax
+++ b/Vue Component.sublime-syntax
@@ -516,10 +516,10 @@ contexts:
     - include: main
 
   vue-directive:
-    - match: \b(v-[\w-]+)\b
+    - match: \b(v-[.|:|\w-]+)\b
       scope: entity.other.attribute-name.html
       push: js-attribute-value
-    - match: \B(:|@)([\w-]+)\b
+    - match: \B(:|@)([.|\w-]+)\b
       captures:
         1: punctuation.definition.attribute.html
         2: entity.other.attribute-name.html

--- a/Vue Component.sublime-syntax.yaml-macros
+++ b/Vue Component.sublime-syntax.yaml-macros
@@ -57,10 +57,10 @@ contexts: !merge
     - include: main
 
   vue-directive:
-    - match: \b(v-[\w-]+)\b
+    - match: \b(v-[\w\:\.-]+)\b
       scope: entity.other.attribute-name.html
       push: js-attribute-value
-    - match: \B(:|@)([\w-]+)\b
+    - match: \B(:|@)([\w\.-]+)\b
       captures:
         1: punctuation.definition.attribute.html
         2: entity.other.attribute-name.html
@@ -235,7 +235,7 @@ contexts: !merge
         - match: '(>)'
           captures:
             1: meta.tag.style.begin.html punctuation.definition.tag.end.html
-          embed: scope:source.sass
+          embed: scope:source.scss
           escape: (?i)(?=</style)
         - match: ''
           push:


### PR DESCRIPTION
This fixes a bug where `lang="scss"` was highlighting in sass instead of scss #126

This also fixes an issue where if you use an event modifier like `@click.prevent` or if you're just using `v-on:` it wasn't highlighting the code in javascript.