### PR TITLE
source.less -> source.css.less

### DIFF
--- a/vue.YAML-tmLanguage
+++ b/vue.YAML-tmLanguage
@@ -190,7 +190,7 @@ patterns:
       '1': {name: punctuation.definition.tag.end.html}
     end: (?=</(?i:style))
     patterns:
-    - include: source.less
+    - include: source.css.less
 
 - name: source.css.embedded.html
   begin: (?:^\s+)?(<)((?i:style))\b(?![^>]*/>)

--- a/vue.tmLanguage
+++ b/vue.tmLanguage
@@ -635,7 +635,7 @@
 					<array>
 						<dict>
 							<key>include</key>
-							<string>source.less</string>
+							<string>source.css.less</string>
 						</dict>
 					</array>
 				</dict>


### PR DESCRIPTION
LESS has changed the main scope from `source.less` to `source.css.less`. This is fitting as LESS is a superset of CSS. More importantly, it enables features like auto completions provided by packages that target CSS for scopes where LESS and CSS are compatible. In particular it enables the (excellent) auto completions for properties and values provided by the default CSS package. 