### PR TITLE
Fully integrated Sublime 3.1 syntax changes.

### DIFF
--- a/HTML.yaml
+++ b/HTML.yaml
@@ -13,8 +13,33 @@ first_line_match: (?i)<(!DOCTYPE\s*)?html
 scope: text.html.basic
 
 variables:
+  attribute_char: (?:[^ "'>/=\x00-\x1f\x7f-\x9f])
   unquoted_attribute_value: (?:[^\s<>/''"]|/(?!>))+
   not_equals_lookahead: (?=\s*[^\s=])
+
+  block_tag_name: |-
+    (?ix)(?:
+      address|applet|article|aside|blockquote|center|dd|dir|div|dl|dt|figcaption|figure|footer|frame|frameset|h1|h2|h3|h4|h5|h6|header|iframe|menu|nav|noframes|object|ol|p|pre|section|ul
+    )\b
+
+  inline_tag_name: |-
+    (?ix)(?:
+      abbr|acronym|area|audio|b|base|basefont|bdi|bdo|big|br|canvas|caption|cite|code|del|details|dfn|dialog|em|font|head|html|i|img|ins|isindex|kbd|li|link|map|mark|menu|menuitem|meta|noscript|param|picture|q|rp|rt|rtc|ruby|s|samp|script|small|source|span|strike|strong|style|sub|summary|sup|time|title|track|tt|u|var|video|wbr
+    )\b
+
+  form_tag_name: |-
+    (?ix)(?:
+      button|datalist|input|label|legend|meter|optgroup|option|output|progress|select|template|textarea
+    )\b
+
+  javascript_mime_type: |-
+    (?ix)(?:
+      # https://mimesniff.spec.whatwg.org/#javascript-mime-type
+      (?:application|text)/(?:x-)?(?:java|ecma)script
+      | text/javascript1\.[0-5]
+      | text/jscript
+      | text/livescript
+    )
 
 contexts:
   immediately-pop:
@@ -38,16 +63,18 @@ contexts:
         - include: tag-generic-attribute
         - include: string-double-quoted
         - include: string-single-quoted
-    - match: <!--
-      scope: punctuation.definition.comment.begin.html
+    - match: (<!--)(-?>)?
+      captures:
+        1: punctuation.definition.comment.begin.html
+        2: invalid.illegal.bad-comments-or-CDATA.html
       push:
         - meta_scope: comment.block.html
-        - match: '(-*)--\s*>'
-          scope: punctuation.definition.comment.end.html
+        - match: '(<!-)?(--\s*>)'
           captures:
             1: invalid.illegal.bad-comments-or-CDATA.html
+            2: punctuation.definition.comment.end.html
           pop: true
-        - match: -{2,}
+        - match: '<!--(?!-?>)|--!>'
           scope: invalid.illegal.bad-comments-or-CDATA.html
     - match: <!
       scope: punctuation.definition.tag.html
@@ -81,58 +108,18 @@ contexts:
           scope: punctuation.definition.tag.end.html
           pop: true
         - include: tag-attributes
-    - match: '(?:^\s+)?(<)((?i:style))\b(?![^>]*/>)'
+    - match: (<)((?i:style))\b
       captures:
         0: meta.tag.style.begin.html
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.style.html
-      push:
-        - match: (?i)(</)(style)(>)
-          captures:
-            0: meta.tag.style.end.html
-            1: punctuation.definition.tag.begin.html
-            2: entity.name.tag.style.html
-            3: punctuation.definition.tag.end.html
-          pop: true
-        - match: '(>)\s*'
-          captures:
-            1: meta.tag.style.begin.html punctuation.definition.tag.end.html
-          embed: scope:source.css
-          embed_scope: source.css.embedded.html
-          escape: (?i)(?=</style)
-        - match: ''
-          push:
-            - meta_scope: meta.tag.style.begin.html
-            - match: '(?=>)'
-              pop: true
-            - include: tag-attributes
-    - match: '(<)((?i:script))\b(?![^>]*/>)(?![^>]*(?i:type.?=.?text/((?!javascript).*)))'
+      push: style-css
+    - match: '(<)((?i:script))\b'
       captures:
         0: meta.tag.script.begin.html
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.script.html
-      push:
-        - match: (?i)(-->)?\s*(</)(script)(>)
-          captures:
-            0: meta.tag.script.end.html
-            1: comment.block.html punctuation.definition.comment.html
-            2: punctuation.definition.tag.begin.html
-            3: entity.name.tag.script.html
-            4: punctuation.definition.tag.end.html
-          pop: true
-        - match: '(>)\s*(<!--)?'
-          captures:
-            1: meta.tag.script.begin.html punctuation.definition.tag.end.html
-            2: comment.block.html punctuation.definition.comment.html
-          embed: scope:source.js
-          embed_scope: source.js.embedded.html
-          escape: (?i)(?=(-->)?\s*</script)
-        - match: ''
-          push:
-            - meta_scope: meta.tag.script.begin.html
-            - match: '(?=>)'
-              pop: true
-            - include: tag-attributes
+      push: script-javascript
     - match: (</?)((?i:body|head|html)\b)
       captures:
         1: punctuation.definition.tag.begin.html
@@ -143,7 +130,7 @@ contexts:
           scope: punctuation.definition.tag.end.html
           pop: true
         - include: tag-attributes
-    - match: (</?)((?i:address|blockquote|dd|div|section|article|aside|header|footer|nav|menu|dl|dt|frame|frameset|h1|h2|h3|h4|h5|h6|iframe|noframes|object|ol|p|ul|applet|center|dir|pre)\b)
+    - match: (</?)({{block_tag_name}})
       captures:
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.block.any.html
@@ -173,7 +160,7 @@ contexts:
           scope: punctuation.definition.tag.end.html
           pop: true
         - include: tag-attributes
-    - match: (</?)((?i:abbr|acronym|area|b|base|basefont|bdo|big|br|caption|cite|code|del|dfn|em|font|head|html|i|img|ins|isindex|kbd|li|link|map|meta|noscript|param|q|s|samp|script|small|span|strike|strong|style|sub|sup|title|tt|u|var)\b)
+    - match: (</?)({{inline_tag_name}})
       captures:
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.inline.any.html
@@ -183,7 +170,7 @@ contexts:
           scope: punctuation.definition.tag.end.html
           pop: true
         - include: tag-attributes
-    - match: (</?)((?i:button|input|label|legend|optgroup|option|select|textarea)\b)
+    - match: (</?)({{form_tag_name}})
       captures:
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.inline.form.html
@@ -236,18 +223,180 @@ contexts:
     - include: entities
     - match: <>
       scope: invalid.illegal.incomplete.html
-  entities-common:
-    - match: (&)([a-zA-Z0-9]+|#[0-9]+|#x[0-9a-fA-F]+)(;)
-      scope: constant.character.entity.html
+
+  entities:
+    - match: (&#[xX])(\h+)(;)
+      scope: constant.character.entity.hexadecimal.html
       captures:
         1: punctuation.definition.entity.html
         3: punctuation.definition.entity.html
-  attribute-entities:
-    - include: entities-common
-  entities:
-    - include: entities-common
-    - match: '&'
-      scope: invalid.illegal.bad-ampersand.html
+    - match: (&#)([0-9]+)(;)
+      scope: constant.character.entity.decimal.html
+      captures:
+        1: punctuation.definition.entity.html
+        3: punctuation.definition.entity.html
+    - match: (&)([a-zA-Z0-9]+)(;)
+      scope: constant.character.entity.named.html
+      captures:
+        1: punctuation.definition.entity.html
+        3: punctuation.definition.entity.html
+
+  style-css:
+    - meta_content_scope: meta.tag.style.begin.html
+    - include: style-common
+    - match: '>'
+      scope: punctuation.definition.tag.end.html
+      set:
+        - include: style-close-tag
+        - match: ''
+          embed: scope:source.css
+          embed_scope: source.css.embedded.html
+          escape: (?i)(?=(?:-->\s*)?</style)
+
+  style-other:
+    - meta_content_scope: meta.tag.style.begin.html
+    - include: style-common
+    - match: '>'
+      scope: punctuation.definition.tag.end.html
+      set:
+        - include: style-close-tag
+
+  style-close-tag:
+    - match: (?i)(</)(style)(>)
+      scope: meta.tag.style.end.html
+      captures:
+        1: punctuation.definition.tag.begin.html
+        2: entity.name.tag.style.html
+        3: punctuation.definition.tag.end.html
+      pop: true
+
+  style-common:
+    - include: style-type-attribute
+    - include: tag-attributes
+    - match: '/>'
+      scope: punctuation.definition.tag.end.html
+      pop: true
+
+  style-type-attribute:
+    - match: (?i)\btype\b
+      scope: meta.attribute-with-value.html entity.other.attribute-name.html
+      set:
+        - meta_content_scope: meta.tag.style.begin.html meta.attribute-with-value.html
+        - match: =
+          scope: punctuation.separator.key-value.html
+          set:
+            - meta_content_scope: meta.tag.style.begin.html meta.attribute-with-value.html
+            - include: style-type-decider
+        - match: (?=\S)
+          set: style-css
+
+  style-type-decider:
+    - match: (?i)(?=text/css(?!{{unquoted_attribute_value}})|'text/css'|"text/css")
+      set:
+        - style-css
+        - tag-generic-attribute-meta
+        - tag-generic-attribute-value
+    - match: (?i)(?=>|''|"")
+      set:
+        - style-css
+        - tag-generic-attribute-meta
+        - tag-generic-attribute-value
+    - match: (?=\S)
+      set:
+        - style-other
+        - tag-generic-attribute-meta
+        - tag-generic-attribute-value
+
+  script-javascript:
+    - meta_content_scope: meta.tag.script.begin.html
+    - include: script-common
+    - match: '>'
+      scope: punctuation.definition.tag.end.html
+      set:
+        - include: script-close-tag
+        - match: (?=\S)
+          embed: scope:source.js
+          embed_scope: source.js.embedded.html
+          escape: (?i)(?=(?:-->\s*)?</script)
+
+  script-html:
+    - meta_content_scope: meta.tag.script.begin.html
+    - include: script-common
+    - match: '>'
+      scope: punctuation.definition.tag.end.html
+      set:
+        - meta_content_scope: text.html.embedded.html
+        - include: script-close-tag
+        - include: main
+
+  script-other:
+    - meta_content_scope: meta.tag.script.begin.html
+    - include: script-common
+    - match: '>'
+      scope: punctuation.definition.tag.end.html
+      set:
+        - include: script-close-tag
+
+  script-close-tag:
+    - match: \s*(<!--)
+      captures:
+        1: comment.block.html punctuation.definition.comment.begin.html
+    - match: (?i)(?:(-->)\s*)?(</)(script)(>)
+      scope: meta.tag.script.end.html
+      captures:
+        1: comment.block.html punctuation.definition.comment.end.html
+        2: punctuation.definition.tag.begin.html
+        3: entity.name.tag.script.html
+        4: punctuation.definition.tag.end.html
+      pop: true
+
+  script-common:
+    - include: script-type-attribute
+    - include: tag-attributes
+    - match: '/>'
+      scope: punctuation.definition.tag.end.html
+      pop: true
+
+  script-type-attribute:
+    - match: (?i)\btype\b
+      scope: meta.attribute-with-value.html entity.other.attribute-name.html
+      set:
+        - meta_content_scope: meta.tag.script.begin.html meta.attribute-with-value.html
+        - match: =
+          scope: punctuation.separator.key-value.html
+          set:
+            - meta_content_scope: meta.tag.script.begin.html meta.attribute-with-value.html
+            - include: script-type-decider
+        - match: (?=\S)
+          set: script-javascript
+
+  script-type-decider:
+    - match: (?i)(?={{javascript_mime_type}}(?!{{unquoted_attribute_value}})|'{{javascript_mime_type}}'|"{{javascript_mime_type}}")
+      set:
+        - script-javascript
+        - tag-generic-attribute-meta
+        - tag-generic-attribute-value
+    - match: (?i)(?=module(?!{{unquoted_attribute_value}})|'module'|"module")
+      set:
+        - script-javascript
+        - tag-generic-attribute-meta
+        - tag-generic-attribute-value
+    - match: (?i)(?=>|''|"")
+      set:
+        - script-javascript
+        - tag-generic-attribute-meta
+        - tag-generic-attribute-value
+    - match: (?i)(?=text/html(?!{{unquoted_attribute_value}})|'text/html'|"text/html")
+      set:
+        - script-html
+        - tag-generic-attribute-meta
+        - tag-generic-attribute-value
+    - match: (?=\S)
+      set:
+        - script-other
+        - tag-generic-attribute-meta
+        - tag-generic-attribute-value
+
   string-double-quoted:
     - match: '"'
       scope: punctuation.definition.string.begin.html
@@ -268,14 +417,17 @@ contexts:
         - include: entities
 
   tag-generic-attribute:
-    - match: '[a-zA-Z0-9:\-_.]+'
+    - match: (?={{attribute_char}})
       scope: entity.other.attribute-name.html
       push:
         - tag-generic-attribute-meta
         - tag-generic-attribute-equals
-        
-    - match: '[a-zA-Z0-9:\-_.]+'
-      scope: entity.other.attribute-name.html
+        - generic-attribute-name
+
+  generic-attribute-name:
+    - meta_scope: entity.other.attribute-name.html
+    - match: (?!{{attribute_char}})
+      pop: true
 
   tag-generic-attribute-meta:
     - meta_scope: meta.attribute-with-value.html
@@ -296,7 +448,7 @@ contexts:
         - match: '"'
           scope: punctuation.definition.string.end.html
           pop: true
-        - include: attribute-entities
+        - include: entities
     - match: "'"
       scope: punctuation.definition.string.begin.html
       set:
@@ -304,9 +456,10 @@ contexts:
         - match: "'"
           scope: punctuation.definition.string.end.html
           pop: true
-        - include: attribute-entities
+        - include: entities
     - match: '{{unquoted_attribute_value}}'
       scope: string.unquoted.html
+      pop: true
     - include: else-pop
 
   tag-class-attribute:
@@ -336,7 +489,7 @@ contexts:
         - match: '"'
           scope: punctuation.definition.string.end.html
           pop: true
-        - include: attribute-entities
+        - include: entities
     - match: "'"
       scope: punctuation.definition.string.begin.html
       set:
@@ -345,9 +498,10 @@ contexts:
         - match: "'"
           scope: punctuation.definition.string.end.html
           pop: true
-        - include: attribute-entities
+        - include: entities
     - match: '{{unquoted_attribute_value}}'
       scope: string.unquoted.html meta.class-name.html
+      pop: true
     - include: else-pop
 
   tag-id-attribute:
@@ -377,7 +531,7 @@ contexts:
         - match: '"'
           scope: punctuation.definition.string.end.html
           pop: true
-        - include: attribute-entities
+        - include: entities
     - match: "'"
       scope: punctuation.definition.string.begin.html
       set:
@@ -386,9 +540,10 @@ contexts:
         - match: "'"
           scope: punctuation.definition.string.end.html
           pop: true
-        - include: attribute-entities
+        - include: entities
     - match: '{{unquoted_attribute_value}}'
       scope: string.unquoted.html meta.toc-list.id.html
+      pop: true
     - include: else-pop
 
   tag-style-attribute:
@@ -429,7 +584,7 @@ contexts:
   tag-event-attribute:
     - match: |-
         (?x)\bon(
-          abort|autocomplete|autocompleteerror|blur|cancel|canplay
+          abort|autocomplete|autocompleteerror|auxclick|blur|cancel|canplay
           |canplaythrough|change|click|close|contextmenu|cuechange|dblclick|drag
           |dragend|dragenter|dragexit|dragleave|dragover|dragstart|drop
           |durationchange|emptied|ended|error|focus|input|invalid|keydown
@@ -471,6 +626,10 @@ contexts:
       escape_captures:
         0: string.quoted.single punctuation.definition.string.end.html
     - include: else-pop
+
+  # This is to prevent breaking syntaxes referencing the old context name
+  tag-stuff:
+    - include: tag-attributes
 
   tag-attributes:
     - include: tag-id-attribute

--- a/Vue Component.sublime-syntax
+++ b/Vue Component.sublime-syntax
@@ -644,44 +644,6 @@ contexts:
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.template.html
       push: template-mustache
-    # - match: '(?i)(<)(template)\b'
-    #   captures:
-    #     0: meta.tag.template.begin.html
-    #     1: punctuation.definition.tag.begin.html
-    #     2: entity.name.tag.template.html
-    #   push:
-    #     - match: (?i)(</)(template)(>)
-    #       captures:
-    #         0: meta.tag.template.end.html
-    #         1: punctuation.definition.tag.begin.html
-    #         2: entity.name.tag.template.html
-    #         3: punctuation.definition.tag.end.html
-    #       pop: true
-    #     - match: '>'
-    #       scope: meta.tag.template.begin.html punctuation.definition.tag.end.html
-    #       push: mustache-template
-    #     - match: ''
-    #       push:
-    #         - meta_scope: meta.tag.template.begin.html
-    #         - match: '(?=>)'
-    #           pop: true
-    #         - include: tag-attributes
-
-  mustache-template:
-    - match: (?=</template)
-      pop: true
-    - match: '{{'
-      scope: punctuation.definition.template.begin.html
-      push:
-        - match: '}}'
-          scope: punctuation.definition.template.end.html
-          pop: true
-        - match: ''
-          push: scope:source.js
-          with_prototype:
-            - match: (?=}})
-              pop: true
-    - include: main
 
   vue-directive:
     - match: \b(v-[\w\:\.-]+)\b
@@ -702,26 +664,16 @@ contexts:
   js-string:
     - match: '"'
       scope: punctuation.definition.string.begin.html
-      push:
-        - match: '"'
-          scope: punctuation.definition.string.end.html
-          pop: true
-        - match: ''
-          push: scope:source.js
-          with_prototype:
-            - match: (?=")
-              pop: true
+      embed: scope:source.js
+      escape: '"'
+      escape_captures:
+        0: punctuation.definition.string.end.html
     - match: "'"
       scope: punctuation.definition.string.begin.html
-      push:
-        - match: "'"
-          scope: punctuation.definition.string.end.html
-          pop: true
-        - match: ''
-          push: scope:source.js
-          with_prototype:
-            - match: (?=')
-              pop: true
+      embed: scope:source.js
+      escape: "'"
+      escape_captures:
+        0: punctuation.definition.string.end.html
 
     - include: else-pop
 

--- a/Vue Component.sublime-syntax
+++ b/Vue Component.sublime-syntax
@@ -5,8 +5,33 @@ file_extensions: [vue]
 first_line_match: (?i)<(!DOCTYPE\s*)?html
 scope: text.html.vue
 variables:
+  attribute_char: (?:[^ "'>/=\x00-\x1f\x7f-\x9f])
   unquoted_attribute_value: (?:[^\s<>/''"]|/(?!>))+
   not_equals_lookahead: (?=\s*[^\s=])
+
+  block_tag_name: |-
+    (?ix)(?:
+      address|applet|article|aside|blockquote|center|dd|dir|div|dl|dt|figcaption|figure|footer|frame|frameset|h1|h2|h3|h4|h5|h6|header|iframe|menu|nav|noframes|object|ol|p|pre|section|ul
+    )\b
+
+  inline_tag_name: |-
+    (?ix)(?:
+      abbr|acronym|area|audio|b|base|basefont|bdi|bdo|big|br|canvas|caption|cite|code|del|details|dfn|dialog|em|font|head|html|i|img|ins|isindex|kbd|li|link|map|mark|menu|menuitem|meta|noscript|param|picture|q|rp|rt|rtc|ruby|s|samp|script|small|source|span|strike|strong|style|sub|summary|sup|time|title|track|tt|u|var|video|wbr
+    )\b
+
+  form_tag_name: |-
+    (?ix)(?:
+      button|datalist|input|label|legend|meter|optgroup|option|output|progress|select|template|textarea
+    )\b
+
+  javascript_mime_type: |-
+    (?ix)(?:
+      # https://mimesniff.spec.whatwg.org/#javascript-mime-type
+      (?:application|text)/(?:x-)?(?:java|ecma)script
+      | text/javascript1\.[0-5]
+      | text/jscript
+      | text/livescript
+    )
 
 contexts:
   immediately-pop:
@@ -18,7 +43,6 @@ contexts:
       pop: true
 
   main:
-    - include: langs
     - include: template-tag
 
     - match: (<\?)(xml)
@@ -33,16 +57,18 @@ contexts:
         - include: tag-generic-attribute
         - include: string-double-quoted
         - include: string-single-quoted
-    - match: <!--
-      scope: punctuation.definition.comment.begin.html
+    - match: (<!--)(-?>)?
+      captures:
+        1: punctuation.definition.comment.begin.html
+        2: invalid.illegal.bad-comments-or-CDATA.html
       push:
         - meta_scope: comment.block.html
-        - match: (-*)--\s*>
-          scope: punctuation.definition.comment.end.html
+        - match: (<!-)?(--\s*>)
           captures:
             1: invalid.illegal.bad-comments-or-CDATA.html
+            2: punctuation.definition.comment.end.html
           pop: true
-        - match: -{2,}
+        - match: <!--(?!-?>)|--!>
           scope: invalid.illegal.bad-comments-or-CDATA.html
     - match: <!
       scope: punctuation.definition.tag.html
@@ -76,58 +102,18 @@ contexts:
           scope: punctuation.definition.tag.end.html
           pop: true
         - include: tag-attributes
-    - match: (?:^\s+)?(<)((?i:style))\b(?![^>]*/>)
+    - match: (<)((?i:style))\b
       captures:
         0: meta.tag.style.begin.html
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.style.html
-      push:
-        - match: (?i)(</)(style)(>)
-          captures:
-            0: meta.tag.style.end.html
-            1: punctuation.definition.tag.begin.html
-            2: entity.name.tag.style.html
-            3: punctuation.definition.tag.end.html
-          pop: true
-        - match: (>)\s*
-          captures:
-            1: meta.tag.style.begin.html punctuation.definition.tag.end.html
-          embed: scope:source.css
-          embed_scope: source.css.embedded.html
-          escape: (?i)(?=</style)
-        - match: ''
-          push:
-            - meta_scope: meta.tag.style.begin.html
-            - match: (?=>)
-              pop: true
-            - include: tag-attributes
-    - match: (<)((?i:script))\b(?![^>]*/>)(?![^>]*(?i:type.?=.?text/((?!javascript).*)))
+      push: style-css
+    - match: (<)((?i:script))\b
       captures:
         0: meta.tag.script.begin.html
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.script.html
-      push:
-        - match: (?i)(-->)?\s*(</)(script)(>)
-          captures:
-            0: meta.tag.script.end.html
-            1: comment.block.html punctuation.definition.comment.html
-            2: punctuation.definition.tag.begin.html
-            3: entity.name.tag.script.html
-            4: punctuation.definition.tag.end.html
-          pop: true
-        - match: (>)\s*(<!--)?
-          captures:
-            1: meta.tag.script.begin.html punctuation.definition.tag.end.html
-            2: comment.block.html punctuation.definition.comment.html
-          embed: scope:source.js
-          embed_scope: source.js.embedded.html
-          escape: (?i)(?=(-->)?\s*</script)
-        - match: ''
-          push:
-            - meta_scope: meta.tag.script.begin.html
-            - match: (?=>)
-              pop: true
-            - include: tag-attributes
+      push: script-javascript
     - match: (</?)((?i:body|head|html)\b)
       captures:
         1: punctuation.definition.tag.begin.html
@@ -138,7 +124,7 @@ contexts:
           scope: punctuation.definition.tag.end.html
           pop: true
         - include: tag-attributes
-    - match: (</?)((?i:address|blockquote|dd|div|section|article|aside|header|footer|nav|menu|dl|dt|frame|frameset|h1|h2|h3|h4|h5|h6|iframe|noframes|object|ol|p|ul|applet|center|dir|pre)\b)
+    - match: (</?)({{block_tag_name}})
       captures:
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.block.any.html
@@ -168,7 +154,7 @@ contexts:
           scope: punctuation.definition.tag.end.html
           pop: true
         - include: tag-attributes
-    - match: (</?)((?i:abbr|acronym|area|b|base|basefont|bdo|big|br|caption|cite|code|del|dfn|em|font|head|html|i|img|ins|isindex|kbd|li|link|map|meta|noscript|param|q|s|samp|script|small|span|strike|strong|style|sub|sup|title|tt|u|var)\b)
+    - match: (</?)({{inline_tag_name}})
       captures:
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.inline.any.html
@@ -178,7 +164,7 @@ contexts:
           scope: punctuation.definition.tag.end.html
           pop: true
         - include: tag-attributes
-    - match: (</?)((?i:button|input|label|legend|optgroup|option|select|textarea)\b)
+    - match: (</?)({{form_tag_name}})
       captures:
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.inline.form.html
@@ -231,18 +217,184 @@ contexts:
     - include: entities
     - match: <>
       scope: invalid.illegal.incomplete.html
-  entities-common:
-    - match: (&)([a-zA-Z0-9]+|#[0-9]+|#x[0-9a-fA-F]+)(;)
-      scope: constant.character.entity.html
+
+  entities:
+    - match: (&#[xX])(\h+)(;)
+      scope: constant.character.entity.hexadecimal.html
       captures:
         1: punctuation.definition.entity.html
         3: punctuation.definition.entity.html
-  attribute-entities:
-    - include: entities-common
-  entities:
-    - include: entities-common
-    - match: '&'
-      scope: invalid.illegal.bad-ampersand.html
+    - match: (&#)([0-9]+)(;)
+      scope: constant.character.entity.decimal.html
+      captures:
+        1: punctuation.definition.entity.html
+        3: punctuation.definition.entity.html
+    - match: (&)([a-zA-Z0-9]+)(;)
+      scope: constant.character.entity.named.html
+      captures:
+        1: punctuation.definition.entity.html
+        3: punctuation.definition.entity.html
+
+  style-css:
+    - meta_content_scope: meta.tag.style.begin.html
+    - include: style-common
+    - match: '>'
+      scope: punctuation.definition.tag.end.html
+      set:
+        - include: style-close-tag
+        - match: ''
+          embed: scope:source.css
+          embed_scope: source.css.embedded.html
+          escape: (?i)(?=(?:-->\s*)?</style)
+
+  style-other:
+    - meta_content_scope: meta.tag.style.begin.html
+    - include: style-common
+    - match: '>'
+      scope: punctuation.definition.tag.end.html
+      set:
+        - include: style-close-tag
+
+  style-close-tag:
+    - match: (?i)(</)(style)(>)
+      scope: meta.tag.style.end.html
+      captures:
+        1: punctuation.definition.tag.begin.html
+        2: entity.name.tag.style.html
+        3: punctuation.definition.tag.end.html
+      pop: true
+
+  style-common:
+    - include: style-lang-attribute
+
+    - include: style-type-attribute
+    - include: tag-attributes
+    - match: />
+      scope: punctuation.definition.tag.end.html
+      pop: true
+
+  style-type-attribute:
+    - match: (?i)\btype\b
+      scope: meta.attribute-with-value.html entity.other.attribute-name.html
+      set:
+        - meta_content_scope: meta.tag.style.begin.html meta.attribute-with-value.html
+        - match: =
+          scope: punctuation.separator.key-value.html
+          set:
+            - meta_content_scope: meta.tag.style.begin.html meta.attribute-with-value.html
+            - include: style-type-decider
+        - match: (?=\S)
+          set: style-css
+
+  style-type-decider:
+    - match: (?i)(?=text/css(?!{{unquoted_attribute_value}})|'text/css'|"text/css")
+      set:
+        - style-css
+        - tag-generic-attribute-meta
+        - tag-generic-attribute-value
+    - match: (?i)(?=>|''|"")
+      set:
+        - style-css
+        - tag-generic-attribute-meta
+        - tag-generic-attribute-value
+    - match: (?=\S)
+      set:
+        - style-other
+        - tag-generic-attribute-meta
+        - tag-generic-attribute-value
+
+  script-javascript:
+    - meta_content_scope: meta.tag.script.begin.html
+    - include: script-common
+    - match: '>'
+      scope: punctuation.definition.tag.end.html
+      set:
+        - include: script-close-tag
+        - match: (?=\S)
+          embed: scope:source.js
+          embed_scope: source.js.embedded.html
+          escape: (?i)(?=(?:-->\s*)?</script)
+
+  script-html:
+    - meta_content_scope: meta.tag.script.begin.html
+    - include: script-common
+    - match: '>'
+      scope: punctuation.definition.tag.end.html
+      set:
+        - meta_content_scope: text.html.embedded.html
+        - include: script-close-tag
+        - include: main
+
+  script-other:
+    - meta_content_scope: meta.tag.script.begin.html
+    - include: script-common
+    - match: '>'
+      scope: punctuation.definition.tag.end.html
+      set:
+        - include: script-close-tag
+
+  script-close-tag:
+    - match: \s*(<!--)
+      captures:
+        1: comment.block.html punctuation.definition.comment.begin.html
+    - match: (?i)(?:(-->)\s*)?(</)(script)(>)
+      scope: meta.tag.script.end.html
+      captures:
+        1: comment.block.html punctuation.definition.comment.end.html
+        2: punctuation.definition.tag.begin.html
+        3: entity.name.tag.script.html
+        4: punctuation.definition.tag.end.html
+      pop: true
+
+  script-common:
+    - include: script-lang-attribute
+
+    - include: script-type-attribute
+    - include: tag-attributes
+    - match: />
+      scope: punctuation.definition.tag.end.html
+      pop: true
+
+  script-type-attribute:
+    - match: (?i)\btype\b
+      scope: meta.attribute-with-value.html entity.other.attribute-name.html
+      set:
+        - meta_content_scope: meta.tag.script.begin.html meta.attribute-with-value.html
+        - match: =
+          scope: punctuation.separator.key-value.html
+          set:
+            - meta_content_scope: meta.tag.script.begin.html meta.attribute-with-value.html
+            - include: script-type-decider
+        - match: (?=\S)
+          set: script-javascript
+
+  script-type-decider:
+    - match: (?i)(?={{javascript_mime_type}}(?!{{unquoted_attribute_value}})|'{{javascript_mime_type}}'|"{{javascript_mime_type}}")
+      set:
+        - script-javascript
+        - tag-generic-attribute-meta
+        - tag-generic-attribute-value
+    - match: (?i)(?=module(?!{{unquoted_attribute_value}})|'module'|"module")
+      set:
+        - script-javascript
+        - tag-generic-attribute-meta
+        - tag-generic-attribute-value
+    - match: (?i)(?=>|''|"")
+      set:
+        - script-javascript
+        - tag-generic-attribute-meta
+        - tag-generic-attribute-value
+    - match: (?i)(?=text/html(?!{{unquoted_attribute_value}})|'text/html'|"text/html")
+      set:
+        - script-html
+        - tag-generic-attribute-meta
+        - tag-generic-attribute-value
+    - match: (?=\S)
+      set:
+        - script-other
+        - tag-generic-attribute-meta
+        - tag-generic-attribute-value
+
   string-double-quoted:
     - match: '"'
       scope: punctuation.definition.string.begin.html
@@ -263,14 +415,17 @@ contexts:
         - include: entities
 
   tag-generic-attribute:
-    - match: '[a-zA-Z0-9:\-_.]+'
+    - match: (?={{attribute_char}})
       scope: entity.other.attribute-name.html
       push:
         - tag-generic-attribute-meta
         - tag-generic-attribute-equals
+        - generic-attribute-name
 
-    - match: '[a-zA-Z0-9:\-_.]+'
-      scope: entity.other.attribute-name.html
+  generic-attribute-name:
+    - meta_scope: entity.other.attribute-name.html
+    - match: (?!{{attribute_char}})
+      pop: true
 
   tag-generic-attribute-meta:
     - meta_scope: meta.attribute-with-value.html
@@ -291,7 +446,7 @@ contexts:
         - match: '"'
           scope: punctuation.definition.string.end.html
           pop: true
-        - include: attribute-entities
+        - include: entities
     - match: "'"
       scope: punctuation.definition.string.begin.html
       set:
@@ -299,9 +454,10 @@ contexts:
         - match: "'"
           scope: punctuation.definition.string.end.html
           pop: true
-        - include: attribute-entities
+        - include: entities
     - match: '{{unquoted_attribute_value}}'
       scope: string.unquoted.html
+      pop: true
     - include: else-pop
 
   tag-class-attribute:
@@ -331,7 +487,7 @@ contexts:
         - match: '"'
           scope: punctuation.definition.string.end.html
           pop: true
-        - include: attribute-entities
+        - include: entities
     - match: "'"
       scope: punctuation.definition.string.begin.html
       set:
@@ -340,9 +496,10 @@ contexts:
         - match: "'"
           scope: punctuation.definition.string.end.html
           pop: true
-        - include: attribute-entities
+        - include: entities
     - match: '{{unquoted_attribute_value}}'
       scope: string.unquoted.html meta.class-name.html
+      pop: true
     - include: else-pop
 
   tag-id-attribute:
@@ -372,7 +529,7 @@ contexts:
         - match: '"'
           scope: punctuation.definition.string.end.html
           pop: true
-        - include: attribute-entities
+        - include: entities
     - match: "'"
       scope: punctuation.definition.string.begin.html
       set:
@@ -381,9 +538,10 @@ contexts:
         - match: "'"
           scope: punctuation.definition.string.end.html
           pop: true
-        - include: attribute-entities
+        - include: entities
     - match: '{{unquoted_attribute_value}}'
       scope: string.unquoted.html meta.toc-list.id.html
+      pop: true
     - include: else-pop
 
   tag-style-attribute:
@@ -424,7 +582,7 @@ contexts:
   tag-event-attribute:
     - match: |-
         (?x)\bon(
-          abort|autocomplete|autocompleteerror|blur|cancel|canplay
+          abort|autocomplete|autocompleteerror|auxclick|blur|cancel|canplay
           |canplaythrough|change|click|close|contextmenu|cuechange|dblclick|drag
           |dragend|dragenter|dragexit|dragleave|dragover|dragstart|drop
           |durationchange|emptied|ended|error|focus|input|invalid|keydown
@@ -467,6 +625,10 @@ contexts:
         0: string.quoted.single punctuation.definition.string.end.html
     - include: else-pop
 
+  # This is to prevent breaking syntaxes referencing the old context name
+  tag-stuff:
+    - include: tag-attributes
+
   tag-attributes:
     - include: vue-directive
 
@@ -476,28 +638,34 @@ contexts:
     - include: tag-event-attribute
     - include: tag-generic-attribute
   template-tag:
-    - match: (?i)(<)(template)\b
+    - match: (<)((?i:template))\b
       captures:
         0: meta.tag.template.begin.html
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.template.html
-      push:
-        - match: (?i)(</)(template)(>)
-          captures:
-            0: meta.tag.template.end.html
-            1: punctuation.definition.tag.begin.html
-            2: entity.name.tag.template.html
-            3: punctuation.definition.tag.end.html
-          pop: true
-        - match: '>'
-          scope: meta.tag.template.begin.html punctuation.definition.tag.end.html
-          push: mustache-template
-        - match: ''
-          push:
-            - meta_scope: meta.tag.template.begin.html
-            - match: (?=>)
-              pop: true
-            - include: tag-attributes
+      push: template-mustache
+    # - match: '(?i)(<)(template)\b'
+    #   captures:
+    #     0: meta.tag.template.begin.html
+    #     1: punctuation.definition.tag.begin.html
+    #     2: entity.name.tag.template.html
+    #   push:
+    #     - match: (?i)(</)(template)(>)
+    #       captures:
+    #         0: meta.tag.template.end.html
+    #         1: punctuation.definition.tag.begin.html
+    #         2: entity.name.tag.template.html
+    #         3: punctuation.definition.tag.end.html
+    #       pop: true
+    #     - match: '>'
+    #       scope: meta.tag.template.begin.html punctuation.definition.tag.end.html
+    #       push: mustache-template
+    #     - match: ''
+    #       push:
+    #         - meta_scope: meta.tag.template.begin.html
+    #         - match: '(?=>)'
+    #           pop: true
+    #         - include: tag-attributes
 
   mustache-template:
     - match: (?=</template)
@@ -557,318 +725,253 @@ contexts:
 
     - include: else-pop
 
-  langs:
-    - match: (?i)(<)((?:script))\b(?=[^>]*lang=(['"])coffee?)
-      captures:
-        0: meta.tag.script.begin.html
-        1: punctuation.definition.tag.begin.html
-        2: entity.name.tag.script.html
-      push:
-        - match: (?i)(</)(script)(>)
-          captures:
-            0: meta.tag.script.end.html
-            1: punctuation.definition.tag.begin.html
-            2: entity.name.tag.script.html
-            3: punctuation.definition.tag.end.html
-          pop: true
-        - match: (>)
-          captures:
-            1: meta.tag.script.begin.html punctuation.definition.tag.end.html
-          embed: scope:source.coffee
-          escape: (?i)(?=</script)
-        - match: ''
-          push:
-            - meta_scope: meta.tag.script.begin.html
-            - match: (?=>)
-              pop: true
-            - include: tag-attributes
-    - match: (?i)(<)((?:script))\b(?=[^>]*lang=(['"])livescript?)
-      captures:
-        0: meta.tag.script.begin.html
-        1: punctuation.definition.tag.begin.html
-        2: entity.name.tag.script.html
-      push:
-        - match: (?i)(</)(script)(>)
-          captures:
-            0: meta.tag.script.end.html
-            1: punctuation.definition.tag.begin.html
-            2: entity.name.tag.script.html
-            3: punctuation.definition.tag.end.html
-          pop: true
-        - match: (>)
-          captures:
-            1: meta.tag.script.begin.html punctuation.definition.tag.end.html
-          embed: scope:source.livescript
-          escape: (?i)(?=</script)
-        - match: ''
-          push:
-            - meta_scope: meta.tag.script.begin.html
-            - match: (?=>)
-              pop: true
-            - include: tag-attributes
-    - match: (?i)(<)((?:script))\b(?=[^>]*lang=(['"])ts?)
-      captures:
-        0: meta.tag.script.begin.html
-        1: punctuation.definition.tag.begin.html
-        2: entity.name.tag.script.html
-      push:
-        - match: (?i)(</)(script)(>)
-          captures:
-            0: meta.tag.script.end.html
-            1: punctuation.definition.tag.begin.html
-            2: entity.name.tag.script.html
-            3: punctuation.definition.tag.end.html
-          pop: true
-        - match: (>)
-          captures:
-            1: meta.tag.script.begin.html punctuation.definition.tag.end.html
-          embed: scope:source.ts
-          escape: (?i)(?=</script)
-        - match: ''
-          push:
-            - meta_scope: meta.tag.script.begin.html
-            - match: (?=>)
-              pop: true
-            - include: tag-attributes
-    - match: (?i)(<)((?:script))\b(?=[^>]*)
-      captures:
-        0: meta.tag.script.begin.html
-        1: punctuation.definition.tag.begin.html
-        2: entity.name.tag.script.html
-      push:
-        - match: (?i)(</)(script)(>)
-          captures:
-            0: meta.tag.script.end.html
-            1: punctuation.definition.tag.begin.html
-            2: entity.name.tag.script.html
-            3: punctuation.definition.tag.end.html
-          pop: true
-        - match: (>)
-          captures:
-            1: meta.tag.script.begin.html punctuation.definition.tag.end.html
-          embed: scope:source.js
-          escape: (?i)(?=</script)
-        - match: ''
-          push:
-            - meta_scope: meta.tag.script.begin.html
-            - match: (?=>)
-              pop: true
-            - include: tag-attributes
-    - match: (?i)(<)((?:style))\b(?=[^>]*lang=(['"])sass?)
-      captures:
-        0: meta.tag.style.begin.html
-        1: punctuation.definition.tag.begin.html
-        2: entity.name.tag.style.html
-      push:
-        - match: (?i)(</)(style)(>)
-          captures:
-            0: meta.tag.style.end.html
-            1: punctuation.definition.tag.begin.html
-            2: entity.name.tag.style.html
-            3: punctuation.definition.tag.end.html
-          pop: true
-        - match: (>)
-          captures:
-            1: meta.tag.style.begin.html punctuation.definition.tag.end.html
-          embed: scope:source.sass
-          escape: (?i)(?=</style)
-        - match: ''
-          push:
-            - meta_scope: meta.tag.style.begin.html
-            - match: (?=>)
-              pop: true
-            - include: tag-attributes
-    - match: (?i)(<)((?:style))\b(?=[^>]*lang=(['"])scss?)
-      captures:
-        0: meta.tag.style.begin.html
-        1: punctuation.definition.tag.begin.html
-        2: entity.name.tag.style.html
-      push:
-        - match: (?i)(</)(style)(>)
-          captures:
-            0: meta.tag.style.end.html
-            1: punctuation.definition.tag.begin.html
-            2: entity.name.tag.style.html
-            3: punctuation.definition.tag.end.html
-          pop: true
-        - match: (>)
-          captures:
-            1: meta.tag.style.begin.html punctuation.definition.tag.end.html
-          embed: scope:source.scss
-          escape: (?i)(?=</style)
-        - match: ''
-          push:
-            - meta_scope: meta.tag.style.begin.html
-            - match: (?=>)
-              pop: true
-            - include: tag-attributes
-    - match: (?i)(<)((?:style))\b(?=[^>]*lang=(['"])stylus?)
-      captures:
-        0: meta.tag.style.begin.html
-        1: punctuation.definition.tag.begin.html
-        2: entity.name.tag.style.html
-      push:
-        - match: (?i)(</)(style)(>)
-          captures:
-            0: meta.tag.style.end.html
-            1: punctuation.definition.tag.begin.html
-            2: entity.name.tag.style.html
-            3: punctuation.definition.tag.end.html
-          pop: true
-        - match: (>)
-          captures:
-            1: meta.tag.style.begin.html punctuation.definition.tag.end.html
-          embed: scope:source.stylus
-          escape: (?i)(?=</style)
-        - match: ''
-          push:
-            - meta_scope: meta.tag.style.begin.html
-            - match: (?=>)
-              pop: true
-            - include: tag-attributes
-    - match: (?i)(<)((?:style))\b(?=[^>]*lang=(['"])postcss?)
-      captures:
-        0: meta.tag.style.begin.html
-        1: punctuation.definition.tag.begin.html
-        2: entity.name.tag.style.html
-      push:
-        - match: (?i)(</)(style)(>)
-          captures:
-            0: meta.tag.style.end.html
-            1: punctuation.definition.tag.begin.html
-            2: entity.name.tag.style.html
-            3: punctuation.definition.tag.end.html
-          pop: true
-        - match: (>)
-          captures:
-            1: meta.tag.style.begin.html punctuation.definition.tag.end.html
-          embed: scope:source.postcss
-          escape: (?i)(?=</style)
-        - match: ''
-          push:
-            - meta_scope: meta.tag.style.begin.html
-            - match: (?=>)
-              pop: true
-            - include: tag-attributes
-    - match: (?i)(<)((?:style))\b(?=[^>]*lang=(['"])less?)
-      captures:
-        0: meta.tag.style.begin.html
-        1: punctuation.definition.tag.begin.html
-        2: entity.name.tag.style.html
-      push:
-        - match: (?i)(</)(style)(>)
-          captures:
-            0: meta.tag.style.end.html
-            1: punctuation.definition.tag.begin.html
-            2: entity.name.tag.style.html
-            3: punctuation.definition.tag.end.html
-          pop: true
-        - match: (>)
-          captures:
-            1: meta.tag.style.begin.html punctuation.definition.tag.end.html
-          embed: scope:source.css.less
-          escape: (?i)(?=</style)
-        - match: ''
-          push:
-            - meta_scope: meta.tag.style.begin.html
-            - match: (?=>)
-              pop: true
-            - include: tag-attributes
-    - match: (?i)(<)((?:style))\b(?=[^>]*)
-      captures:
-        0: meta.tag.style.begin.html
-        1: punctuation.definition.tag.begin.html
-        2: entity.name.tag.style.html
-      push:
-        - match: (?i)(</)(style)(>)
-          captures:
-            0: meta.tag.style.end.html
-            1: punctuation.definition.tag.begin.html
-            2: entity.name.tag.style.html
-            3: punctuation.definition.tag.end.html
-          pop: true
-        - match: (>)
-          captures:
-            1: meta.tag.style.begin.html punctuation.definition.tag.end.html
-          embed: scope:source.css
-          escape: (?i)(?=</style)
-        - match: ''
-          push:
-            - meta_scope: meta.tag.style.begin.html
-            - match: (?=>)
-              pop: true
-            - include: tag-attributes
-    - match: (?i)(<)((?:template))\b(?=[^>]*lang=(['"])jade?)
-      captures:
-        0: meta.tag.template.begin.html
-        1: punctuation.definition.tag.begin.html
-        2: entity.name.tag.template.html
-      push:
-        - match: (?i)(</)(template)(>)
-          captures:
-            0: meta.tag.template.end.html
-            1: punctuation.definition.tag.begin.html
-            2: entity.name.tag.template.html
-            3: punctuation.definition.tag.end.html
-          pop: true
-        - match: (>)
-          captures:
-            1: meta.tag.template.begin.html punctuation.definition.tag.end.html
-          embed: scope:text.jade
-          escape: (?i)(?=</template)
-        - match: ''
-          push:
-            - meta_scope: meta.tag.template.begin.html
-            - match: (?=>)
-              pop: true
-            - include: tag-attributes
-    - match: (?i)(<)((?:template))\b(?=[^>]*lang=(['"])pug?)
-      captures:
-        0: meta.tag.template.begin.html
-        1: punctuation.definition.tag.begin.html
-        2: entity.name.tag.template.html
-      push:
-        - match: (?i)(</)(template)(>)
-          captures:
-            0: meta.tag.template.end.html
-            1: punctuation.definition.tag.begin.html
-            2: entity.name.tag.template.html
-            3: punctuation.definition.tag.end.html
-          pop: true
-        - match: (>)
-          captures:
-            1: meta.tag.template.begin.html punctuation.definition.tag.end.html
-          embed: scope:text.pug
-          escape: (?i)(?=</template)
-        - match: ''
-          push:
-            - meta_scope: meta.tag.template.begin.html
-            - match: (?=>)
-              pop: true
-            - include: tag-attributes
-    - match: (?i)(<)((?:template))\b(?=[^>]*lang=(['"])slm?)
-      captures:
-        0: meta.tag.template.begin.html
-        1: punctuation.definition.tag.begin.html
-        2: entity.name.tag.template.html
-      push:
-        - match: (?i)(</)(template)(>)
-          captures:
-            0: meta.tag.template.end.html
-            1: punctuation.definition.tag.begin.html
-            2: entity.name.tag.template.html
-            3: punctuation.definition.tag.end.html
-          pop: true
-        - match: (>)
-          captures:
-            1: meta.tag.template.begin.html punctuation.definition.tag.end.html
-          embed: scope:text.slm
-          escape: (?i)(?=</template)
-        - match: ''
-          push:
-            - meta_scope: meta.tag.template.begin.html
-            - match: (?=>)
-              pop: true
-            - include: tag-attributes
+  style-lang-attribute:
+    - match: (?i)\blang\b
+      scope: meta.attribute-with-value.html entity.other.attribute-name.html
+      set:
+        - meta_content_scope: meta.tag.style.begin.html meta.attribute-with-value.html
+        - match: =
+          scope: punctuation.separator.key-value.html
+          set:
+            - meta_content_scope: meta.tag.style.begin.html meta.attribute-with-value.html
+            - include: style-lang-decider
+        - match: (?=\S)
+          set: style-css
 
+  style-lang-decider:
+    - match: (?i)(?=sass(?!{{unquoted_attribute_value}})|\'sass\'|"sass")
+      set:
+        -   - meta_content_scope: meta.tag.style.begin.html
+            - include: style-common
+            - match: '>'
+              scope: punctuation.definition.tag.end.html
+              set:
+                - include: style-close-tag
+                - match: (?=\S)
+                  embed_scope: source.sass.embedded.html
+                  embed: scope:source.sass
+                  escape: (?i)(?=(?:-->\s*)?</style)
+        - tag-generic-attribute-meta
+        - tag-generic-attribute-value
+    - match: (?i)(?=scss(?!{{unquoted_attribute_value}})|\'scss\'|"scss")
+      set:
+        -   - meta_content_scope: meta.tag.style.begin.html
+            - include: style-common
+            - match: '>'
+              scope: punctuation.definition.tag.end.html
+              set:
+                - include: style-close-tag
+                - match: (?=\S)
+                  embed_scope: source.scss.embedded.html
+                  embed: scope:source.scss
+                  escape: (?i)(?=(?:-->\s*)?</style)
+        - tag-generic-attribute-meta
+        - tag-generic-attribute-value
+    - match: (?i)(?=stylus(?!{{unquoted_attribute_value}})|\'stylus\'|"stylus")
+      set:
+        -   - meta_content_scope: meta.tag.style.begin.html
+            - include: style-common
+            - match: '>'
+              scope: punctuation.definition.tag.end.html
+              set:
+                - include: style-close-tag
+                - match: (?=\S)
+                  embed_scope: source.stylus.embedded.html
+                  embed: scope:source.stylus
+                  escape: (?i)(?=(?:-->\s*)?</style)
+        - tag-generic-attribute-meta
+        - tag-generic-attribute-value
+    - match: (?i)(?=postcss(?!{{unquoted_attribute_value}})|\'postcss\'|"postcss")
+      set:
+        -   - meta_content_scope: meta.tag.style.begin.html
+            - include: style-common
+            - match: '>'
+              scope: punctuation.definition.tag.end.html
+              set:
+                - include: style-close-tag
+                - match: (?=\S)
+                  embed_scope: source.postcss.embedded.html
+                  embed: scope:source.postcss
+                  escape: (?i)(?=(?:-->\s*)?</style)
+        - tag-generic-attribute-meta
+        - tag-generic-attribute-value
+    - match: (?i)(?=less(?!{{unquoted_attribute_value}})|\'less\'|"less")
+      set:
+        -   - meta_content_scope: meta.tag.style.begin.html
+            - include: style-common
+            - match: '>'
+              scope: punctuation.definition.tag.end.html
+              set:
+                - include: style-close-tag
+                - match: (?=\S)
+                  embed_scope: source.css.less.embedded.html
+                  embed: scope:source.css.less
+                  escape: (?i)(?=(?:-->\s*)?</style)
+        - tag-generic-attribute-meta
+        - tag-generic-attribute-value
+    - match: (?=\S)
+      set:
+        - style-css
+        - tag-generic-attribute-meta
+        - tag-generic-attribute-value
+
+  script-lang-attribute:
+    - match: (?i)\blang\b
+      scope: meta.attribute-with-value.html entity.other.attribute-name.html
+      set:
+        - meta_content_scope: meta.tag.script.begin.html meta.attribute-with-value.html
+        - match: =
+          scope: punctuation.separator.key-value.html
+          set:
+            - meta_content_scope: meta.tag.script.begin.html meta.attribute-with-value.html
+            - include: script-lang-decider
+        - match: (?=\S)
+          set: script-javascript
+
+  script-lang-decider:
+    - match: (?i)(?=coffee(?!{{unquoted_attribute_value}})|\'coffee\'|"coffee")
+      set:
+        -   - meta_content_scope: meta.tag.script.begin.html
+            - include: script-common
+            - match: '>'
+              scope: punctuation.definition.tag.end.html
+              set:
+                - include: script-close-tag
+                - match: (?=\S)
+                  embed_scope: source.coffee.embedded.html
+                  embed: scope:source.coffee
+                  escape: (?i)(?=(?:-->\s*)?</script)
+        - tag-generic-attribute-meta
+        - tag-generic-attribute-value
+    - match: (?i)(?=livescript(?!{{unquoted_attribute_value}})|\'livescript\'|"livescript")
+      set:
+        -   - meta_content_scope: meta.tag.script.begin.html
+            - include: script-common
+            - match: '>'
+              scope: punctuation.definition.tag.end.html
+              set:
+                - include: script-close-tag
+                - match: (?=\S)
+                  embed_scope: source.livescript.embedded.html
+                  embed: scope:source.livescript
+                  escape: (?i)(?=(?:-->\s*)?</script)
+        - tag-generic-attribute-meta
+        - tag-generic-attribute-value
+    - match: (?i)(?=ts(?!{{unquoted_attribute_value}})|\'ts\'|"ts")
+      set:
+        -   - meta_content_scope: meta.tag.script.begin.html
+            - include: script-common
+            - match: '>'
+              scope: punctuation.definition.tag.end.html
+              set:
+                - include: script-close-tag
+                - match: (?=\S)
+                  embed_scope: source.ts.embedded.html
+                  embed: scope:source.ts
+                  escape: (?i)(?=(?:-->\s*)?</script)
+        - tag-generic-attribute-meta
+        - tag-generic-attribute-value
+    - match: (?=\S)
+      set:
+        - script-javascript
+        - tag-generic-attribute-meta
+        - tag-generic-attribute-value
+
+  template-common:
+    - include: template-lang-attribute
+    - include: tag-attributes
+    - match: />
+      scope: punctuation.definition.tag.end.html
+      pop: true
+
+  template-close-tag:
+    - match: (?i)(</)(template)(>)
+      scope: meta.tag.template.end.html
+      captures:
+        1: punctuation.definition.tag.begin.html
+        2: entity.name.tag.template.html
+        3: punctuation.definition.tag.end.html
+      pop: true
+
+  template-mustache:
+    - meta_content_scope: meta.tag.template.begin.html
+    - include: template-common
+    - match: '>'
+      scope: punctuation.definition.tag.end.html
+      set:
+        - include: template-close-tag
+        - match: ''
+          push: scope:text.html.basic
+          with_prototype:
+            - match: (?=</template)
+              pop: true
+            - match: '{{'
+              scope: punctuation.definition.template.begin.html
+              embed: scope:source.js
+              escape: '}}|(?=</template)'
+              escape_captures:
+                0: punctuation.definition.template.end.html
+
+
+  template-lang-attribute:
+    - match: (?i)\blang\b
+      scope: meta.attribute-with-value.html entity.other.attribute-name.html
+      set:
+        - meta_content_scope: meta.tag.template.begin.html meta.attribute-with-value.html
+        - match: =
+          scope: punctuation.separator.key-value.html
+          set:
+            - meta_content_scope: meta.tag.template.begin.html meta.attribute-with-value.html
+            - include: template-lang-decider
+        - match: (?=\S)
+          set: template-mustache
+
+  template-lang-decider:
+    - match: (?i)(?=jade(?!{{unquoted_attribute_value}})|\'jade\'|"jade")
+      set:
+        -   - meta_content_scope: meta.tag.template.begin.html
+            - include: template-common
+            - match: '>'
+              scope: punctuation.definition.tag.end.html
+              set:
+                - include: template-close-tag
+                - match: (?=\S)
+                  embed_scope: text.jade.embedded.html
+                  embed: scope:text.jade
+                  escape: (?i)(?=(?:-->\s*)?</template)
+        - tag-generic-attribute-meta
+        - tag-generic-attribute-value
+    - match: (?i)(?=pug(?!{{unquoted_attribute_value}})|\'pug\'|"pug")
+      set:
+        -   - meta_content_scope: meta.tag.template.begin.html
+            - include: template-common
+            - match: '>'
+              scope: punctuation.definition.tag.end.html
+              set:
+                - include: template-close-tag
+                - match: (?=\S)
+                  embed_scope: text.pug.embedded.html
+                  embed: scope:text.pug
+                  escape: (?i)(?=(?:-->\s*)?</template)
+        - tag-generic-attribute-meta
+        - tag-generic-attribute-value
+    - match: (?i)(?=slm(?!{{unquoted_attribute_value}})|\'slm\'|"slm")
+      set:
+        -   - meta_content_scope: meta.tag.template.begin.html
+            - include: template-common
+            - match: '>'
+              scope: punctuation.definition.tag.end.html
+              set:
+                - include: template-close-tag
+                - match: (?=\S)
+                  embed_scope: text.slm.embedded.html
+                  embed: scope:text.slm
+                  escape: (?i)(?=(?:-->\s*)?</template)
+        - tag-generic-attribute-meta
+        - tag-generic-attribute-value
+    - match: (?=\S)
+      set:
+        - template-mustache
+        - tag-generic-attribute-meta
+        - tag-generic-attribute-value
 hidden: false

--- a/Vue Component.sublime-syntax
+++ b/Vue Component.sublime-syntax
@@ -708,8 +708,8 @@ contexts:
               scope: punctuation.definition.tag.end.html
               set:
                 - include: style-close-tag
-                - match: (?=\S)
-                  embed_scope: source.sass.embedded.html
+                - embed_scope: source.sass.embedded.html
+                  match: ''
                   embed: scope:source.sass
                   escape: (?i)(?=(?:-->\s*)?</style)
         - tag-generic-attribute-meta
@@ -722,8 +722,8 @@ contexts:
               scope: punctuation.definition.tag.end.html
               set:
                 - include: style-close-tag
-                - match: (?=\S)
-                  embed_scope: source.scss.embedded.html
+                - embed_scope: source.scss.embedded.html
+                  match: ''
                   embed: scope:source.scss
                   escape: (?i)(?=(?:-->\s*)?</style)
         - tag-generic-attribute-meta
@@ -736,8 +736,8 @@ contexts:
               scope: punctuation.definition.tag.end.html
               set:
                 - include: style-close-tag
-                - match: (?=\S)
-                  embed_scope: source.stylus.embedded.html
+                - embed_scope: source.stylus.embedded.html
+                  match: ''
                   embed: scope:source.stylus
                   escape: (?i)(?=(?:-->\s*)?</style)
         - tag-generic-attribute-meta
@@ -750,8 +750,8 @@ contexts:
               scope: punctuation.definition.tag.end.html
               set:
                 - include: style-close-tag
-                - match: (?=\S)
-                  embed_scope: source.postcss.embedded.html
+                - embed_scope: source.postcss.embedded.html
+                  match: ''
                   embed: scope:source.postcss
                   escape: (?i)(?=(?:-->\s*)?</style)
         - tag-generic-attribute-meta
@@ -764,8 +764,8 @@ contexts:
               scope: punctuation.definition.tag.end.html
               set:
                 - include: style-close-tag
-                - match: (?=\S)
-                  embed_scope: source.css.less.embedded.html
+                - embed_scope: source.css.less.embedded.html
+                  match: ''
                   embed: scope:source.css.less
                   escape: (?i)(?=(?:-->\s*)?</style)
         - tag-generic-attribute-meta
@@ -798,8 +798,8 @@ contexts:
               scope: punctuation.definition.tag.end.html
               set:
                 - include: script-close-tag
-                - match: (?=\S)
-                  embed_scope: source.coffee.embedded.html
+                - embed_scope: source.coffee.embedded.html
+                  match: ''
                   embed: scope:source.coffee
                   escape: (?i)(?=(?:-->\s*)?</script)
         - tag-generic-attribute-meta
@@ -812,8 +812,8 @@ contexts:
               scope: punctuation.definition.tag.end.html
               set:
                 - include: script-close-tag
-                - match: (?=\S)
-                  embed_scope: source.livescript.embedded.html
+                - embed_scope: source.livescript.embedded.html
+                  match: ''
                   embed: scope:source.livescript
                   escape: (?i)(?=(?:-->\s*)?</script)
         - tag-generic-attribute-meta
@@ -826,8 +826,8 @@ contexts:
               scope: punctuation.definition.tag.end.html
               set:
                 - include: script-close-tag
-                - match: (?=\S)
-                  embed_scope: source.ts.embedded.html
+                - embed_scope: source.ts.embedded.html
+                  match: ''
                   embed: scope:source.ts
                   escape: (?i)(?=(?:-->\s*)?</script)
         - tag-generic-attribute-meta
@@ -886,8 +886,8 @@ contexts:
               scope: punctuation.definition.tag.end.html
               set:
                 - include: template-close-tag
-                - match: (?=\S)
-                  embed_scope: text.jade.embedded.html
+                - embed_scope: text.jade.embedded.html
+                  match: ''
                   embed: scope:text.jade
                   escape: (?i)(?=(?:-->\s*)?</template)
         - tag-generic-attribute-meta
@@ -900,8 +900,8 @@ contexts:
               scope: punctuation.definition.tag.end.html
               set:
                 - include: template-close-tag
-                - match: (?=\S)
-                  embed_scope: text.pug.embedded.html
+                - embed_scope: text.pug.embedded.html
+                  match: ''
                   embed: scope:text.pug
                   escape: (?i)(?=(?:-->\s*)?</template)
         - tag-generic-attribute-meta
@@ -914,8 +914,8 @@ contexts:
               scope: punctuation.definition.tag.end.html
               set:
                 - include: template-close-tag
-                - match: (?=\S)
-                  embed_scope: text.slm.embedded.html
+                - embed_scope: text.slm.embedded.html
+                  match: ''
                   embed: scope:text.slm
                   escape: (?i)(?=(?:-->\s*)?</template)
         - tag-generic-attribute-meta

--- a/Vue Component.sublime-syntax
+++ b/Vue Component.sublime-syntax
@@ -44,6 +44,7 @@ contexts:
 
   main:
     - include: template-tag
+    - include: mustache-expression
 
     - match: (<\?)(xml)
       captures:
@@ -637,6 +638,14 @@ contexts:
     - include: tag-style-attribute
     - include: tag-event-attribute
     - include: tag-generic-attribute
+  mustache-expression:
+    - match: '{{'
+      scope: punctuation.definition.template.begin.html
+      embed: scope:source.js
+      escape: '}}'
+      escape_captures:
+        0: punctuation.definition.template.end.html
+
   template-tag:
     - match: (<)((?i:template))\b
       captures:
@@ -853,17 +862,7 @@ contexts:
       set:
         - include: template-close-tag
         - match: ''
-          push: scope:text.html.basic
-          with_prototype:
-            - match: (?=</template)
-              pop: true
-            - match: '{{'
-              scope: punctuation.definition.template.begin.html
-              embed: scope:source.js
-              escape: '}}|(?=</template)'
-              escape_captures:
-                0: punctuation.definition.template.end.html
-
+          push: main
 
   template-lang-attribute:
     - match: (?i)\blang\b

--- a/Vue Component.sublime-syntax.yaml-macros
+++ b/Vue Component.sublime-syntax.yaml-macros
@@ -1,5 +1,5 @@
 %YAML 1.2
-%TAG ! tag:yaml-macros:YAMLMacros.lib.extend:
+%TAG ! tag:yaml-macros:macros:
 ---
 !extend
 _base: HTML.yaml
@@ -10,51 +10,18 @@ file_extensions: [vue]
 
 contexts: !merge
   main: !prepend
-    - include: langs
     - include: template-tag
 
   tag-attributes: !prepend
     - include: vue-directive
 
   template-tag:
-    - match: '(?i)(<)(template)\b'
+    - match: (<)((?i:template))\b
       captures:
         0: meta.tag.template.begin.html
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.template.html
-      push:
-        - match: (?i)(</)(template)(>)
-          captures:
-            0: meta.tag.template.end.html
-            1: punctuation.definition.tag.begin.html
-            2: entity.name.tag.template.html
-            3: punctuation.definition.tag.end.html
-          pop: true
-        - match: '>'
-          scope: meta.tag.template.begin.html punctuation.definition.tag.end.html
-          push: mustache-template
-        - match: ''
-          push:
-            - meta_scope: meta.tag.template.begin.html
-            - match: '(?=>)'
-              pop: true
-            - include: tag-attributes
-
-  mustache-template:
-    - match: (?=</template)
-      pop: true
-    - match: '{{'
-      scope: punctuation.definition.template.begin.html
-      push:
-        - match: '}}'
-          scope: punctuation.definition.template.end.html
-          pop: true
-        - match: ''
-          push: scope:source.js
-          with_prototype:
-            - match: (?=}})
-              pop: true
-    - include: main
+      push: template-mustache
 
   vue-directive:
     - match: \b(v-[\w\:\.-]+)\b
@@ -98,317 +65,115 @@ contexts: !merge
 
     - include: else-pop
 
-  langs:
-    - match: (?i)(<)((?:script))\b(?=[^>]*lang=(['"])coffee?)
-      captures:
-        0: meta.tag.script.begin.html
-        1: punctuation.definition.tag.begin.html
-        2: entity.name.tag.script.html
-      push:
-        - match: (?i)(</)(script)(>)
-          captures:
-            0: meta.tag.script.end.html
-            1: punctuation.definition.tag.begin.html
-            2: entity.name.tag.script.html
-            3: punctuation.definition.tag.end.html
-          pop: true
-        - match: '(>)'
-          captures:
-            1: meta.tag.script.begin.html punctuation.definition.tag.end.html
-          embed: scope:source.coffee
-          escape: (?i)(?=</script)
-        - match: ''
-          push:
-            - meta_scope: meta.tag.script.begin.html
-            - match: '(?=>)'
-              pop: true
-            - include: tag-attributes
-    - match: (?i)(<)((?:script))\b(?=[^>]*lang=(['"])livescript?)
-      captures:
-        0: meta.tag.script.begin.html
-        1: punctuation.definition.tag.begin.html
-        2: entity.name.tag.script.html
-      push:
-        - match: (?i)(</)(script)(>)
-          captures:
-            0: meta.tag.script.end.html
-            1: punctuation.definition.tag.begin.html
-            2: entity.name.tag.script.html
-            3: punctuation.definition.tag.end.html
-          pop: true
-        - match: '(>)'
-          captures:
-            1: meta.tag.script.begin.html punctuation.definition.tag.end.html
-          embed: scope:source.livescript
-          escape: (?i)(?=</script)
-        - match: ''
-          push:
-            - meta_scope: meta.tag.script.begin.html
-            - match: '(?=>)'
-              pop: true
-            - include: tag-attributes
-    - match: (?i)(<)((?:script))\b(?=[^>]*lang=(['"])ts?)
-      captures:
-        0: meta.tag.script.begin.html
-        1: punctuation.definition.tag.begin.html
-        2: entity.name.tag.script.html
-      push:
-        - match: (?i)(</)(script)(>)
-          captures:
-            0: meta.tag.script.end.html
-            1: punctuation.definition.tag.begin.html
-            2: entity.name.tag.script.html
-            3: punctuation.definition.tag.end.html
-          pop: true
-        - match: '(>)'
-          captures:
-            1: meta.tag.script.begin.html punctuation.definition.tag.end.html
-          embed: scope:source.ts
-          escape: (?i)(?=</script)
-        - match: ''
-          push:
-            - meta_scope: meta.tag.script.begin.html
-            - match: '(?=>)'
-              pop: true
-            - include: tag-attributes
-    - match: (?i)(<)((?:script))\b(?=[^>]*)
-      captures:
-        0: meta.tag.script.begin.html
-        1: punctuation.definition.tag.begin.html
-        2: entity.name.tag.script.html
-      push:
-        - match: (?i)(</)(script)(>)
-          captures:
-            0: meta.tag.script.end.html
-            1: punctuation.definition.tag.begin.html
-            2: entity.name.tag.script.html
-            3: punctuation.definition.tag.end.html
-          pop: true
-        - match: '(>)'
-          captures:
-            1: meta.tag.script.begin.html punctuation.definition.tag.end.html
-          embed: scope:source.js
-          escape: (?i)(?=</script)
-        - match: ''
-          push:
-            - meta_scope: meta.tag.script.begin.html
-            - match: '(?=>)'
-              pop: true
-            - include: tag-attributes
-    - match: (?i)(<)((?:style))\b(?=[^>]*lang=(['"])sass?)
-      captures:
-        0: meta.tag.style.begin.html
-        1: punctuation.definition.tag.begin.html
-        2: entity.name.tag.style.html
-      push:
-        - match: (?i)(</)(style)(>)
-          captures:
-            0: meta.tag.style.end.html
-            1: punctuation.definition.tag.begin.html
-            2: entity.name.tag.style.html
-            3: punctuation.definition.tag.end.html
-          pop: true
-        - match: '(>)'
-          captures:
-            1: meta.tag.style.begin.html punctuation.definition.tag.end.html
-          embed: scope:source.sass
-          escape: (?i)(?=</style)
-        - match: ''
-          push:
-            - meta_scope: meta.tag.style.begin.html
-            - match: '(?=>)'
-              pop: true
-            - include: tag-attributes
-    - match: (?i)(<)((?:style))\b(?=[^>]*lang=(['"])scss?)
-      captures:
-        0: meta.tag.style.begin.html
-        1: punctuation.definition.tag.begin.html
-        2: entity.name.tag.style.html
-      push:
-        - match: (?i)(</)(style)(>)
-          captures:
-            0: meta.tag.style.end.html
-            1: punctuation.definition.tag.begin.html
-            2: entity.name.tag.style.html
-            3: punctuation.definition.tag.end.html
-          pop: true
-        - match: '(>)'
-          captures:
-            1: meta.tag.style.begin.html punctuation.definition.tag.end.html
-          embed: scope:source.scss
-          escape: (?i)(?=</style)
-        - match: ''
-          push:
-            - meta_scope: meta.tag.style.begin.html
-            - match: '(?=>)'
-              pop: true
-            - include: tag-attributes
-    - match: (?i)(<)((?:style))\b(?=[^>]*lang=(['"])stylus?)
-      captures:
-        0: meta.tag.style.begin.html
-        1: punctuation.definition.tag.begin.html
-        2: entity.name.tag.style.html
-      push:
-        - match: (?i)(</)(style)(>)
-          captures:
-            0: meta.tag.style.end.html
-            1: punctuation.definition.tag.begin.html
-            2: entity.name.tag.style.html
-            3: punctuation.definition.tag.end.html
-          pop: true
-        - match: '(>)'
-          captures:
-            1: meta.tag.style.begin.html punctuation.definition.tag.end.html
-          embed: scope:source.stylus
-          escape: (?i)(?=</style)
-        - match: ''
-          push:
-            - meta_scope: meta.tag.style.begin.html
-            - match: '(?=>)'
-              pop: true
-            - include: tag-attributes
-    - match: (?i)(<)((?:style))\b(?=[^>]*lang=(['"])postcss?)
-      captures:
-        0: meta.tag.style.begin.html
-        1: punctuation.definition.tag.begin.html
-        2: entity.name.tag.style.html
-      push:
-        - match: (?i)(</)(style)(>)
-          captures:
-            0: meta.tag.style.end.html
-            1: punctuation.definition.tag.begin.html
-            2: entity.name.tag.style.html
-            3: punctuation.definition.tag.end.html
-          pop: true
-        - match: '(>)'
-          captures:
-            1: meta.tag.style.begin.html punctuation.definition.tag.end.html
-          embed: scope:source.postcss
-          escape: (?i)(?=</style)
-        - match: ''
-          push:
-            - meta_scope: meta.tag.style.begin.html
-            - match: '(?=>)'
-              pop: true
-            - include: tag-attributes
-    - match: (?i)(<)((?:style))\b(?=[^>]*lang=(['"])less?)
-      captures:
-        0: meta.tag.style.begin.html
-        1: punctuation.definition.tag.begin.html
-        2: entity.name.tag.style.html
-      push:
-        - match: (?i)(</)(style)(>)
-          captures:
-            0: meta.tag.style.end.html
-            1: punctuation.definition.tag.begin.html
-            2: entity.name.tag.style.html
-            3: punctuation.definition.tag.end.html
-          pop: true
-        - match: '(>)'
-          captures:
-            1: meta.tag.style.begin.html punctuation.definition.tag.end.html
-          embed: scope:source.css.less
-          escape: (?i)(?=</style)
-        - match: ''
-          push:
-            - meta_scope: meta.tag.style.begin.html
-            - match: '(?=>)'
-              pop: true
-            - include: tag-attributes
-    - match: (?i)(<)((?:style))\b(?=[^>]*)
-      captures:
-        0: meta.tag.style.begin.html
-        1: punctuation.definition.tag.begin.html
-        2: entity.name.tag.style.html
-      push:
-        - match: (?i)(</)(style)(>)
-          captures:
-            0: meta.tag.style.end.html
-            1: punctuation.definition.tag.begin.html
-            2: entity.name.tag.style.html
-            3: punctuation.definition.tag.end.html
-          pop: true
-        - match: '(>)'
-          captures:
-            1: meta.tag.style.begin.html punctuation.definition.tag.end.html
-          embed: scope:source.css
-          escape: (?i)(?=</style)
-        - match: ''
-          push:
-            - meta_scope: meta.tag.style.begin.html
-            - match: '(?=>)'
-              pop: true
-            - include: tag-attributes
-    - match: (?i)(<)((?:template))\b(?=[^>]*lang=(['"])jade?)
-      captures:
-        0: meta.tag.template.begin.html
-        1: punctuation.definition.tag.begin.html
-        2: entity.name.tag.template.html
-      push:
-        - match: (?i)(</)(template)(>)
-          captures:
-            0: meta.tag.template.end.html
-            1: punctuation.definition.tag.begin.html
-            2: entity.name.tag.template.html
-            3: punctuation.definition.tag.end.html
-          pop: true
-        - match: '(>)'
-          captures:
-            1: meta.tag.template.begin.html punctuation.definition.tag.end.html
-          embed: scope:text.jade
-          escape: (?i)(?=</template)
-        - match: ''
-          push:
-            - meta_scope: meta.tag.template.begin.html
-            - match: '(?=>)'
-              pop: true
-            - include: tag-attributes
-    - match: (?i)(<)((?:template))\b(?=[^>]*lang=(['"])pug?)
-      captures:
-        0: meta.tag.template.begin.html
-        1: punctuation.definition.tag.begin.html
-        2: entity.name.tag.template.html
-      push:
-        - match: (?i)(</)(template)(>)
-          captures:
-            0: meta.tag.template.end.html
-            1: punctuation.definition.tag.begin.html
-            2: entity.name.tag.template.html
-            3: punctuation.definition.tag.end.html
-          pop: true
-        - match: '(>)'
-          captures:
-            1: meta.tag.template.begin.html punctuation.definition.tag.end.html
-          embed: scope:text.pug
-          escape: (?i)(?=</template)
-        - match: ''
-          push:
-            - meta_scope: meta.tag.template.begin.html
-            - match: '(?=>)'
-              pop: true
-            - include: tag-attributes
-    - match: (?i)(<)((?:template))\b(?=[^>]*lang=(['"])slm?)
-      captures:
-        0: meta.tag.template.begin.html
-        1: punctuation.definition.tag.begin.html
-        2: entity.name.tag.template.html
-      push:
-        - match: (?i)(</)(template)(>)
-          captures:
-            0: meta.tag.template.end.html
-            1: punctuation.definition.tag.begin.html
-            2: entity.name.tag.template.html
-            3: punctuation.definition.tag.end.html
-          pop: true
-        - match: '(>)'
-          captures:
-            1: meta.tag.template.begin.html punctuation.definition.tag.end.html
-          embed: scope:text.slm
-          escape: (?i)(?=</template)
-        - match: ''
-          push:
-            - meta_scope: meta.tag.template.begin.html
-            - match: '(?=>)'
-              pop: true
-            - include: tag-attributes
+  style-common: !prepend
+    - include: style-lang-attribute
 
+  style-lang-attribute:
+    - match: (?i)\blang\b
+      scope: meta.attribute-with-value.html entity.other.attribute-name.html
+      set:
+        - meta_content_scope: meta.tag.style.begin.html meta.attribute-with-value.html
+        - match: =
+          scope: punctuation.separator.key-value.html
+          set:
+            - meta_content_scope: meta.tag.style.begin.html meta.attribute-with-value.html
+            - include: style-lang-decider
+        - match: (?=\S)
+          set: style-css
+
+  style-lang-decider:
+    - !style_language [ sass, source.sass ]
+    - !style_language [ scss, source.scss ]
+    - !style_language [ stylus, source.stylus ]
+    - !style_language [ postcss, source.postcss ]
+    - !style_language [ less, source.css.less ]
+    - match: (?=\S)
+      set:
+        - style-css
+        - tag-generic-attribute-meta
+        - tag-generic-attribute-value
+
+  script-common: !prepend
+    - include: script-lang-attribute
+
+  script-lang-attribute:
+    - match: (?i)\blang\b
+      scope: meta.attribute-with-value.html entity.other.attribute-name.html
+      set:
+        - meta_content_scope: meta.tag.script.begin.html meta.attribute-with-value.html
+        - match: =
+          scope: punctuation.separator.key-value.html
+          set:
+            - meta_content_scope: meta.tag.script.begin.html meta.attribute-with-value.html
+            - include: script-lang-decider
+        - match: (?=\S)
+          set: script-javascript
+
+  script-lang-decider:
+    - !script_language [ coffee, source.coffee ]
+    - !script_language [ livescript, source.livescript ]
+    - !script_language [ ts, source.ts ]
+    - match: (?=\S)
+      set:
+        - script-javascript
+        - tag-generic-attribute-meta
+        - tag-generic-attribute-value
+
+  template-common:
+    - include: template-lang-attribute
+    - include: tag-attributes
+    - match: '/>'
+      scope: punctuation.definition.tag.end.html
+      pop: true
+
+  template-close-tag:
+    - match: (?i)(</)(template)(>)
+      scope: meta.tag.template.end.html
+      captures:
+        1: punctuation.definition.tag.begin.html
+        2: entity.name.tag.template.html
+        3: punctuation.definition.tag.end.html
+      pop: true
+
+  template-mustache:
+    - meta_content_scope: meta.tag.template.begin.html
+    - include: template-common
+    - match: '>'
+      scope: punctuation.definition.tag.end.html
+      set:
+        - include: template-close-tag
+        - match: ''
+          push: scope:text.html.basic
+          with_prototype:
+            - match: (?=</template)
+              pop: true
+            - match: '{{'
+              scope: punctuation.definition.template.begin.html
+              embed: scope:source.js
+              escape: '}}|(?=</template)'
+              escape_captures:
+                0: punctuation.definition.template.end.html
+
+
+  template-lang-attribute:
+    - match: (?i)\blang\b
+      scope: meta.attribute-with-value.html entity.other.attribute-name.html
+      set:
+        - meta_content_scope: meta.tag.template.begin.html meta.attribute-with-value.html
+        - match: =
+          scope: punctuation.separator.key-value.html
+          set:
+            - meta_content_scope: meta.tag.template.begin.html meta.attribute-with-value.html
+            - include: template-lang-decider
+        - match: (?=\S)
+          set: template-mustache
+
+  template-lang-decider:
+    - !template_language [ jade, text.jade ]
+    - !template_language [ pug, text.pug ]
+    - !template_language [ slm, text.slm ]
+    - match: (?=\S)
+      set:
+        - template-mustache
+        - tag-generic-attribute-meta
+        - tag-generic-attribute-value

--- a/Vue Component.sublime-syntax.yaml-macros
+++ b/Vue Component.sublime-syntax.yaml-macros
@@ -42,26 +42,16 @@ contexts: !merge
   js-string:
     - match: '"'
       scope: punctuation.definition.string.begin.html
-      push:
-        - match: '"'
-          scope: punctuation.definition.string.end.html
-          pop: true
-        - match: ''
-          push: scope:source.js
-          with_prototype:
-          - match: (?=")
-            pop: true
+      embed: scope:source.js
+      escape: '"'
+      escape_captures:
+        0: punctuation.definition.string.end.html
     - match: "'"
       scope: punctuation.definition.string.begin.html
-      push:
-        - match: "'"
-          scope: punctuation.definition.string.end.html
-          pop: true
-        - match: ''
-          push: scope:source.js
-          with_prototype:
-          - match: (?=')
-            pop: true
+      embed: scope:source.js
+      escape: "'"
+      escape_captures:
+        0: punctuation.definition.string.end.html
 
     - include: else-pop
 

--- a/Vue Component.sublime-syntax.yaml-macros
+++ b/Vue Component.sublime-syntax.yaml-macros
@@ -11,6 +11,15 @@ file_extensions: [vue]
 contexts: !merge
   main: !prepend
     - include: template-tag
+    - include: mustache-expression
+
+  mustache-expression:
+    - match: '{{'
+      scope: punctuation.definition.template.begin.html
+      embed: scope:source.js
+      escape: '}}'
+      escape_captures:
+        0: punctuation.definition.template.end.html
 
   tag-attributes: !prepend
     - include: vue-directive
@@ -133,17 +142,7 @@ contexts: !merge
       set:
         - include: template-close-tag
         - match: ''
-          push: scope:text.html.basic
-          with_prototype:
-            - match: (?=</template)
-              pop: true
-            - match: '{{'
-              scope: punctuation.definition.template.begin.html
-              embed: scope:source.js
-              escape: '}}|(?=</template)'
-              escape_captures:
-                0: punctuation.definition.template.end.html
-
+          push: main
 
   template-lang-attribute:
     - match: (?i)\blang\b

--- a/macros.py
+++ b/macros.py
@@ -1,0 +1,37 @@
+from YAMLMacros.lib.syntax import rule as _rule
+from YAMLMacros.lib.extend import *
+
+def script_language(match, embed):
+    return embed_language_in_tag('script', match, embed)
+
+def style_language(match, embed):
+    return embed_language_in_tag('style', match, embed)
+
+def template_language(match, embed):
+    return embed_language_in_tag('template', match, embed)
+
+def embed_language_in_tag(tag, match, embed):
+    return _rule(
+        match=r'(?i)(?={0}(?!{{{{unquoted_attribute_value}}}})|\'{0}\'|"{0}")'.format(match),
+        set=[
+            [
+                _rule(meta_content_scope='meta.tag.%s.begin.html' % tag),
+                _rule(include='%s-common' % tag),
+                _rule(
+                    match='>',
+                    scope='punctuation.definition.tag.end.html',
+                    set=[
+                        _rule(include='%s-close-tag' % tag),
+                        _rule(
+                            match=r'(?=\S)',
+                            embed=('scope:%s' % embed),
+                            embed_scope=('%s.embedded.html' % embed),
+                            escape=r'(?i)(?=(?:-->\s*)?</%s)' % tag,
+                        )
+                    ]
+                ),
+            ],
+            'tag-generic-attribute-meta',
+            'tag-generic-attribute-value',
+        ]
+    )

--- a/macros.py
+++ b/macros.py
@@ -23,7 +23,7 @@ def embed_language_in_tag(tag, match, embed):
                     set=[
                         _rule(include='%s-close-tag' % tag),
                         _rule(
-                            match=r'(?=\S)',
+                            match=r'',
                             embed=('scope:%s' % embed),
                             embed_scope=('%s.embedded.html' % embed),
                             escape=r'(?i)(?=(?:-->\s*)?</%s)' % tag,


### PR DESCRIPTION
Updates the `HTML.yaml` base syntax to the latest version from core. The core syntax has been updated substantially since 3.0.

The most noteworthy change is [a new way of parsing `<script>` and `<style>` `type` attributes](https://github.com/sublimehq/Packages/pull/1379). The old way (which this package extended) was based on regexp lookaheads, and it was not very reliable. The new way is much more robust, and this PR uses the new approach for the `lang` attribute of `<script>`, `<style>`, and `<template>` tags. To implement the new approach in this PR, I offloaded most of the boilerplate to a new macro.

Hopefully, this should solve any remaining problems with language detection.

Example of code that should now be correctly highlighted:

```html
<script
lang
=
coffee
>
module.exports =
  data: ->
    msg: 'Hello from coffee!'
</script>
```