### PR TITLE
Add SugarSS highlighting

### DIFF
--- a/Vue Component.sublime-syntax
+++ b/Vue Component.sublime-syntax
@@ -742,6 +742,20 @@ contexts:
                   escape: (?i)(?=(?:-->\s*)?</style)
         - tag-generic-attribute-meta
         - tag-generic-attribute-value
+    - match: (?i)(?=postcss\?parser=sugarss(?!{{unquoted_attribute_value}})|\'postcss\?parser=sugarss\'|"postcss\?parser=sugarss")
+      set:
+        -   - meta_content_scope: meta.tag.style.begin.html
+            - include: style-common
+            - match: '>'
+              scope: punctuation.definition.tag.end.html
+              set:
+                - include: style-close-tag
+                - match: ''
+                  embed_scope: source.sss.embedded.html
+                  embed: scope:source.sss
+                  escape: (?i)(?=(?:-->\s*)?</style)
+        - tag-generic-attribute-meta
+        - tag-generic-attribute-value
     - match: (?i)(?=postcss(?!{{unquoted_attribute_value}})|\'postcss\'|"postcss")
       set:
         -   - meta_content_scope: meta.tag.style.begin.html

--- a/Vue Component.sublime-syntax.yaml-macros
+++ b/Vue Component.sublime-syntax.yaml-macros
@@ -84,6 +84,7 @@ contexts: !merge
     - !style_language [ sass, source.sass ]
     - !style_language [ scss, source.scss ]
     - !style_language [ stylus, source.stylus ]
+    - !style_language [ postcss\?parser=sugarss, source.sss ]
     - !style_language [ postcss, source.postcss ]
     - !style_language [ less, source.css.less ]
     - match: (?=\S)


### PR DESCRIPTION
Second try for #141.

This time I've compiled the .sublime-syntax file from the yaml-macros file with the Sublime Text build function.

before and after my changes:
![2018-05-29_19-16-40](https://user-images.githubusercontent.com/3692190/40653028-dfea5f0a-6374-11e8-8324-3adff57e146b.gif)

`Hero.vue` test file contents:
```
<template lang="pug">
	
	#hero.container

		section.narrow
			img(src="~/assets/images/logo.png" alt="logo")
			.content
				h1
					|some catchphrase,
					.sub
						|really nice slogan
				p
					|more details here
					|in this paragraph text.
					|great!
				nuxt-link(to="/page1/") scroll down


</template>



<style lang="postcss?parser=sugarss">
	
	@import "../assets/vars.sss"

	#hero
		@mixin background-image '../assets/images/hero.png'
		height: 60em
		max-height: 140vw

		// account for header
		padding-top: 6em

		section
			display: flex
			flex-direction: column
			align-items: center
			justify-content: space-between
			height: 100%

			.content
				text-align: center

				a
					@mixin ghost-button $black, white

</style>
```