### PR TITLE
Fix scss scope

### DIFF
--- a/vue.YAML-tmLanguage
+++ b/vue.YAML-tmLanguage
@@ -174,7 +174,7 @@ patterns:
       '1': {name: punctuation.definition.tag.end.html}
     end: (?=</(?i:style))
     patterns:
-    - include: source.scss
+    - include: source.css.scss
 
 - name: source.less.embedded.html
   begin: (?:^\s+)?(<)((?i:style))\b(?=[^>]*lang=(['"])less\1?)

--- a/vue.tmLanguage
+++ b/vue.tmLanguage
@@ -581,7 +581,7 @@
 					<array>
 						<dict>
 							<key>include</key>
-							<string>source.scss</string>
+							<string>source.css.scss</string>
 						</dict>
 					</array>
 				</dict>


### PR DESCRIPTION
This is an attempt to fix https://github.com/vuejs/vue-syntax-highlight/issues/161

I basically did the same thing that were done to fix `less` here: https://github.com/vuejs/vue-syntax-highlight/pull/135

~@braver I assumed that the scope for `sass` changed to, not only the `scss` scope. Is that correct?~ Apologies, I checked the source and the sass scope is still [the same](https://github.com/braver/SublimeSass/blob/e4808c7339d8c2cc6cd4a03de9f199d6bd397674/Syntaxes/Sass.sublime-syntax#L7). I reverted that part of the commit.