### PR TITLE
Scope improvements

### DIFF
--- a/Vue Component.sublime-syntax
+++ b/Vue Component.sublime-syntax
@@ -639,13 +639,18 @@ contexts:
     - include: tag-event-attribute
     - include: tag-generic-attribute
   mustache-expression:
-    - match: '{{'
-      scope: punctuation.definition.template.begin.html
-      embed: scope:source.js
-      embed_scope: source.js.embedded.vue
-      escape: '}}'
-      escape_captures:
-        0: punctuation.definition.template.end.html
+    - match: (?={{)
+      set:
+        - meta_scope: meta.template.vue
+        - match: '{{'
+          scope: punctuation.definition.template.begin.html
+          embed: scope:source.js
+          embed_scope: source.js.embedded.vue
+          escape: '}}'
+          escape_captures:
+            0: meta.template.vue punctuation.definition.template.end.html
+        - match: ''
+          pop: true
 
   template-tag:
     - match: (<)((?i:template))\b

--- a/Vue Component.sublime-syntax
+++ b/Vue Component.sublime-syntax
@@ -642,6 +642,7 @@ contexts:
     - match: '{{'
       scope: punctuation.definition.template.begin.html
       embed: scope:source.js
+      embed_scope: source.js.embedded.vue
       escape: '}}'
       escape_captures:
         0: punctuation.definition.template.end.html
@@ -674,12 +675,14 @@ contexts:
     - match: '"'
       scope: punctuation.definition.string.begin.html
       embed: scope:source.js
+      embed_scope: source.js.embedded.vue
       escape: '"'
       escape_captures:
         0: punctuation.definition.string.end.html
     - match: "'"
       scope: punctuation.definition.string.begin.html
       embed: scope:source.js
+      embed_scope: source.js.embedded.vue
       escape: "'"
       escape_captures:
         0: punctuation.definition.string.end.html

--- a/Vue Component.sublime-syntax.yaml-macros
+++ b/Vue Component.sublime-syntax.yaml-macros
@@ -14,13 +14,18 @@ contexts: !merge
     - include: mustache-expression
 
   mustache-expression:
-    - match: '{{'
-      scope: punctuation.definition.template.begin.html
-      embed: scope:source.js
-      embed_scope: source.js.embedded.vue
-      escape: '}}'
-      escape_captures:
-        0: punctuation.definition.template.end.html
+    - match: '(?={{)'
+      set:
+        - meta_scope: meta.template.vue
+        - match: '{{'
+          scope: punctuation.definition.template.begin.html
+          embed: scope:source.js
+          embed_scope: source.js.embedded.vue
+          escape: '}}'
+          escape_captures:
+            0: meta.template.vue punctuation.definition.template.end.html
+        - match: ''
+          pop: true
 
   tag-attributes: !prepend
     - include: vue-directive

--- a/Vue Component.sublime-syntax.yaml-macros
+++ b/Vue Component.sublime-syntax.yaml-macros
@@ -17,6 +17,7 @@ contexts: !merge
     - match: '{{'
       scope: punctuation.definition.template.begin.html
       embed: scope:source.js
+      embed_scope: source.js.embedded.vue
       escape: '}}'
       escape_captures:
         0: punctuation.definition.template.end.html
@@ -52,12 +53,14 @@ contexts: !merge
     - match: '"'
       scope: punctuation.definition.string.begin.html
       embed: scope:source.js
+      embed_scope: source.js.embedded.vue
       escape: '"'
       escape_captures:
         0: punctuation.definition.string.end.html
     - match: "'"
       scope: punctuation.definition.string.begin.html
       embed: scope:source.js
+      embed_scope: source.js.embedded.vue
       escape: "'"
       escape_captures:
         0: punctuation.definition.string.end.html


### PR DESCRIPTION
Adding a custom `embed_scope` allows to exclude vue embeds from linting, for example, using `source.js - source.js.embedded.vue`, which would otherwise generate a lot of "xy not defined" errors.

For even more granularity, I added a `meta.template.vue` scope for mustache expressions.