### PR TITLE
Add support for coffeescript 2

### DIFF
--- a/samples/langs.vue
+++ b/samples/langs.vue
@@ -39,3 +39,9 @@ module.exports =
   data: ->
     msg: 'Hello from coffee!'
 </script>
+
+<script lang="coffeescript">
+module.exports =
+  data: ->
+    msg: 'Hello from coffeescript!'
+</script>

--- a/vue.YAML-tmLanguage
+++ b/vue.YAML-tmLanguage
@@ -227,7 +227,7 @@ patterns:
     - include: source.ts
 
 - name: source.coffee.embedded.html
-  begin: (?:^\s+)?(<)((?i:script))\b(?=[^>]*lang=(['"])coffee\1?)
+  begin: (?:^\s+)?(<)((?i:script))\b(?=[^>]*lang=(['"])(coffee|coffeescript)\1?)
   beginCaptures:
     '1': {name: punctuation.definition.tag.begin.html}
     '2': {name: entity.name.tag.script.html}

--- a/vue.tmLanguage
+++ b/vue.tmLanguage
@@ -759,7 +759,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>(?:^\s+)?(&lt;)((?i:script))\b(?=[^&gt;]*lang=(['"])coffee\1?)</string>
+			<string>(?:^\s+)?(&lt;)((?i:script))\b(?=[^&gt;]*lang=(['"])(coffee|coffeescript)\1?)</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>


### PR DESCRIPTION
The loader for coffeescript@2  is now named coffeescript-loader. In order to use Vue & coffeescript@2, it needs to be `<script lang="coffeescript">`.