### PR TITLE
🚧 Add support for Gridsome query blocks (#200)

### DIFF
--- a/Vue Component.sublime-syntax
+++ b/Vue Component.sublime-syntax
@@ -1,7 +1,5 @@
 %YAML 1.2
 ---
-name: Vue Component
-file_extensions: [vue]
 scope: text.html.vue
 variables:
   attribute_char: (?:[^ "'>/=\x00-\x1f\x7f-\x9f])
@@ -32,18 +30,258 @@ variables:
       | text/livescript
     )
 
+hidden: false
+first_line_match: (?i)<(!DOCTYPE\s*)?html
+file_extensions: [vue]
 contexts:
-  immediately-pop:
-    - match: ''
+  tag-event-attribute:
+    - match: |-
+        (?x)\bon(
+          abort|autocomplete|autocompleteerror|auxclick|blur|cancel|canplay
+          |canplaythrough|change|click|close|contextmenu|cuechange|dblclick|drag
+          |dragend|dragenter|dragexit|dragleave|dragover|dragstart|drop
+          |durationchange|emptied|ended|error|focus|input|invalid|keydown
+          |keypress|keyup|load|loadeddata|loadedmetadata|loadstart|mousedown
+          |mouseenter|mouseleave|mousemove|mouseout|mouseover|mouseup|mousewheel
+          |pause|play|playing|progress|ratechange|reset|resize|scroll|seeked
+          |seeking|select|show|sort|stalled|submit|suspend|timeupdate|toggle
+          |volumechange|waiting
+        )\b
+      scope: entity.other.attribute-name.event.html
+      push:
+        - tag-event-attribute-meta
+        - tag-event-attribute-equals
+
+  tag-id-attribute-equals:
+    - match: '='
+      scope: punctuation.separator.key-value.html
+      set: tag-id-attribute-value
+    - match: '{{not_equals_lookahead}}'
       pop: true
+
+  tag-generic-attribute-value:
+    - match: '"'
+      scope: punctuation.definition.string.begin.html
+      set:
+        - meta_scope: string.quoted.double.html
+        - match: '"'
+          scope: punctuation.definition.string.end.html
+          pop: true
+        - include: entities
+    - match: "'"
+      scope: punctuation.definition.string.begin.html
+      set:
+        - meta_scope: string.quoted.single.html
+        - match: "'"
+          scope: punctuation.definition.string.end.html
+          pop: true
+        - include: entities
+    - match: '{{unquoted_attribute_value}}'
+      scope: string.unquoted.html
+      pop: true
+    - include: else-pop
+
+  script-other:
+    - meta_content_scope: meta.tag.script.begin.html
+    - include: script-common
+    - match: '>'
+      scope: punctuation.definition.tag.end.html
+      set:
+        - include: script-close-tag
+
+  entities:
+    - match: (&#[xX])(\h+)(;)
+      scope: constant.character.entity.hexadecimal.html
+      captures:
+        1: punctuation.definition.entity.html
+        3: punctuation.definition.entity.html
+    - match: (&#)([0-9]+)(;)
+      scope: constant.character.entity.decimal.html
+      captures:
+        1: punctuation.definition.entity.html
+        3: punctuation.definition.entity.html
+    - match: (&)([a-zA-Z0-9]+)(;)
+      scope: constant.character.entity.named.html
+      captures:
+        1: punctuation.definition.entity.html
+        3: punctuation.definition.entity.html
+
+  vue-directive:
+    - match: \b(v-[\w\:\.-]+)\b
+      scope: entity.other.attribute-name.html
+      push: js-attribute-value
+    - match: \B(:|@)([\w\.-]+)\b
+      captures:
+        1: punctuation.definition.attribute.html
+        2: entity.other.attribute-name.html
+      push: js-attribute-value
+
+  script-html:
+    - meta_content_scope: meta.tag.script.begin.html
+    - include: script-common
+    - match: '>'
+      scope: punctuation.definition.tag.end.html
+      set:
+        - meta_content_scope: text.html.embedded.html
+        - include: script-close-tag
+        - include: main
+
+  script-type-attribute:
+    - match: (?i)\btype\b
+      scope: meta.attribute-with-value.html entity.other.attribute-name.html
+      set:
+        - meta_content_scope: meta.tag.script.begin.html meta.attribute-with-value.html
+        - match: =
+          scope: punctuation.separator.key-value.html
+          set:
+            - meta_content_scope: meta.tag.script.begin.html meta.attribute-with-value.html
+            - include: script-type-decider
+        - match: (?=\S)
+          set: script-javascript
+
+  tag-style-attribute-equals:
+    - match: '='
+      scope: punctuation.separator.key-value.html
+      set: tag-style-attribute-value
+    - match: '{{not_equals_lookahead}}'
+      pop: true
+
+  generic-attribute-name:
+    - meta_scope: entity.other.attribute-name.html
+    - match: (?!{{attribute_char}})
+      pop: true
+
+  script-lang-attribute:
+    - match: (?i)\blang\b
+      scope: meta.attribute-with-value.html entity.other.attribute-name.html
+      set:
+        - meta_content_scope: meta.tag.script.begin.html meta.attribute-with-value.html
+        - match: =
+          scope: punctuation.separator.key-value.html
+          set:
+            - meta_content_scope: meta.tag.script.begin.html meta.attribute-with-value.html
+            - include: script-lang-decider
+        - match: (?=\S)
+          set: script-javascript
 
   else-pop:
     - match: (?=\S)
       pop: true
 
+  tag-id-attribute-value:
+    - match: '"'
+      scope: punctuation.definition.string.begin.html
+      set:
+        - meta_scope: string.quoted.double.html
+        - meta_content_scope: meta.toc-list.id.html
+        - match: '"'
+          scope: punctuation.definition.string.end.html
+          pop: true
+        - include: entities
+    - match: "'"
+      scope: punctuation.definition.string.begin.html
+      set:
+        - meta_scope: string.quoted.single.html
+        - meta_content_scope: meta.toc-list.id.html
+        - match: "'"
+          scope: punctuation.definition.string.end.html
+          pop: true
+        - include: entities
+    - match: '{{unquoted_attribute_value}}'
+      scope: string.unquoted.html meta.toc-list.id.html
+      pop: true
+    - include: else-pop
+
+  template-common:
+    - include: template-lang-attribute
+    - include: tag-attributes
+    - match: />
+      scope: punctuation.definition.tag.end.html
+      pop: true
+
+  tag-event-attribute-equals:
+    - match: '='
+      scope: punctuation.separator.key-value.html
+      set: tag-event-attribute-value
+    - match: '{{not_equals_lookahead}}'
+      pop: true
+
+  tag-style-attribute-value:
+    - match: '"'
+      scope: string.quoted.double punctuation.definition.string.begin.html
+      embed: scope:source.css#rule-list-body
+      embed_scope: source.css
+      escape: '"'
+      escape_captures:
+        0: string.quoted.double punctuation.definition.string.end.html
+    - match: "'"
+      scope: string.quoted.single punctuation.definition.string.begin.html
+      embed: scope:source.css#rule-list-body
+      embed_scope: source.css
+      escape: "'"
+      escape_captures:
+        0: string.quoted.single punctuation.definition.string.end.html
+    - include: else-pop
+
+  tag-style-attribute-meta:
+    - meta_scope: meta.attribute-with-value.style.html
+    - include: immediately-pop
+
+  style-type-decider:
+    - match: (?i)(?=text/css(?!{{unquoted_attribute_value}})|'text/css'|"text/css")
+      set:
+        - style-css
+        - tag-generic-attribute-meta
+        - tag-generic-attribute-value
+    - match: (?i)(?=>|''|"")
+      set:
+        - style-css
+        - tag-generic-attribute-meta
+        - tag-generic-attribute-value
+    - match: (?=\S)
+      set:
+        - style-other
+        - tag-generic-attribute-meta
+        - tag-generic-attribute-value
+
+  mustache-expression:
+    - match: (?={{)
+      set:
+        - meta_scope: meta.template.vue
+        - match: '{{'
+          scope: punctuation.definition.template.begin.html
+          embed: scope:source.js
+          embed_scope: source.js.embedded.vue
+          escape: '}}'
+          escape_captures:
+            0: meta.template.vue punctuation.definition.template.end.html
+        - match: ''
+          pop: true
+
+  tag-id-attribute:
+    - match: \bid\b
+      scope: entity.other.attribute-name.id.html
+      push:
+        - tag-id-attribute-meta
+        - tag-id-attribute-equals
+
+  js-attribute-value:
+    - match: '='
+      scope: punctuation.separator.key-value.html
+      set: js-string
+    - include: else-pop
+
+  tag-class-attribute:
+    - match: \bclass\b
+      scope: entity.other.attribute-name.class.html
+      push:
+        - tag-class-attribute-meta
+        - tag-class-attribute-equals
+
   main:
     - include: template-tag
     - include: mustache-expression
+    - include: query-tag
 
     - match: (<\?)(xml)
       captures:
@@ -218,416 +456,58 @@ contexts:
     - match: <>
       scope: invalid.illegal.incomplete.html
 
-  entities:
-    - match: (&#[xX])(\h+)(;)
-      scope: constant.character.entity.hexadecimal.html
-      captures:
-        1: punctuation.definition.entity.html
-        3: punctuation.definition.entity.html
-    - match: (&#)([0-9]+)(;)
-      scope: constant.character.entity.decimal.html
-      captures:
-        1: punctuation.definition.entity.html
-        3: punctuation.definition.entity.html
-    - match: (&)([a-zA-Z0-9]+)(;)
-      scope: constant.character.entity.named.html
-      captures:
-        1: punctuation.definition.entity.html
-        3: punctuation.definition.entity.html
-
-  style-css:
-    - meta_content_scope: meta.tag.style.begin.html
-    - include: style-common
-    - match: '>'
-      scope: punctuation.definition.tag.end.html
+  script-lang-decider:
+    - match: (?i)(?=coffee(?!{{unquoted_attribute_value}})|\'coffee\'|"coffee")
       set:
-        - include: style-close-tag
-        - match: ''
-          embed: scope:source.css
-          embed_scope: source.css.embedded.html
-          escape: (?i)(?=(?:-->\s*)?</style)
-
-  style-other:
-    - meta_content_scope: meta.tag.style.begin.html
-    - include: style-common
-    - match: '>'
-      scope: punctuation.definition.tag.end.html
-      set:
-        - include: style-close-tag
-
-  style-close-tag:
-    - match: (?i)(</)(style)(>)
-      scope: meta.tag.style.end.html
-      captures:
-        1: punctuation.definition.tag.begin.html
-        2: entity.name.tag.style.html
-        3: punctuation.definition.tag.end.html
-      pop: true
-
-  style-common:
-    - include: style-lang-attribute
-
-    - include: style-type-attribute
-    - include: tag-attributes
-    - match: />
-      scope: punctuation.definition.tag.end.html
-      pop: true
-
-  style-type-attribute:
-    - match: (?i)\btype\b
-      scope: meta.attribute-with-value.html entity.other.attribute-name.html
-      set:
-        - meta_content_scope: meta.tag.style.begin.html meta.attribute-with-value.html
-        - match: =
-          scope: punctuation.separator.key-value.html
-          set:
-            - meta_content_scope: meta.tag.style.begin.html meta.attribute-with-value.html
-            - include: style-type-decider
-        - match: (?=\S)
-          set: style-css
-
-  style-type-decider:
-    - match: (?i)(?=text/css(?!{{unquoted_attribute_value}})|'text/css'|"text/css")
-      set:
-        - style-css
+        -   - meta_content_scope: meta.tag.script.begin.html
+            - include: script-common
+            - match: '>'
+              scope: punctuation.definition.tag.end.html
+              set:
+                - include: script-close-tag
+                - embed_scope: source.coffee.embedded.html
+                  match: ''
+                  embed: scope:source.coffee
+                  escape: (?i)(?=(?:-->\s*)?</script)
         - tag-generic-attribute-meta
         - tag-generic-attribute-value
-    - match: (?i)(?=>|''|"")
+    - match: (?i)(?=livescript(?!{{unquoted_attribute_value}})|\'livescript\'|"livescript")
       set:
-        - style-css
+        -   - meta_content_scope: meta.tag.script.begin.html
+            - include: script-common
+            - match: '>'
+              scope: punctuation.definition.tag.end.html
+              set:
+                - include: script-close-tag
+                - embed_scope: source.livescript.embedded.html
+                  match: ''
+                  embed: scope:source.livescript
+                  escape: (?i)(?=(?:-->\s*)?</script)
+        - tag-generic-attribute-meta
+        - tag-generic-attribute-value
+    - match: (?i)(?=ts(?!{{unquoted_attribute_value}})|\'ts\'|"ts")
+      set:
+        -   - meta_content_scope: meta.tag.script.begin.html
+            - include: script-common
+            - match: '>'
+              scope: punctuation.definition.tag.end.html
+              set:
+                - include: script-close-tag
+                - embed_scope: source.ts.embedded.html
+                  match: ''
+                  embed: scope:source.ts
+                  escape: (?i)(?=(?:-->\s*)?</script)
         - tag-generic-attribute-meta
         - tag-generic-attribute-value
     - match: (?=\S)
       set:
-        - style-other
-        - tag-generic-attribute-meta
-        - tag-generic-attribute-value
-
-  script-javascript:
-    - meta_content_scope: meta.tag.script.begin.html
-    - include: script-common
-    - match: '>'
-      scope: punctuation.definition.tag.end.html
-      set:
-        - include: script-close-tag
-        - match: (?=\S)
-          embed: scope:source.js
-          embed_scope: source.js.embedded.html
-          escape: (?i)(?=(?:-->\s*)?</script)
-
-  script-html:
-    - meta_content_scope: meta.tag.script.begin.html
-    - include: script-common
-    - match: '>'
-      scope: punctuation.definition.tag.end.html
-      set:
-        - meta_content_scope: text.html.embedded.html
-        - include: script-close-tag
-        - include: main
-
-  script-other:
-    - meta_content_scope: meta.tag.script.begin.html
-    - include: script-common
-    - match: '>'
-      scope: punctuation.definition.tag.end.html
-      set:
-        - include: script-close-tag
-
-  script-close-tag:
-    - match: \s*(<!--)
-      captures:
-        1: comment.block.html punctuation.definition.comment.begin.html
-    - match: (?i)(?:(-->)\s*)?(</)(script)(>)
-      scope: meta.tag.script.end.html
-      captures:
-        1: comment.block.html punctuation.definition.comment.end.html
-        2: punctuation.definition.tag.begin.html
-        3: entity.name.tag.script.html
-        4: punctuation.definition.tag.end.html
-      pop: true
-
-  script-common:
-    - include: script-lang-attribute
-
-    - include: script-type-attribute
-    - include: tag-attributes
-    - match: />
-      scope: punctuation.definition.tag.end.html
-      pop: true
-
-  script-type-attribute:
-    - match: (?i)\btype\b
-      scope: meta.attribute-with-value.html entity.other.attribute-name.html
-      set:
-        - meta_content_scope: meta.tag.script.begin.html meta.attribute-with-value.html
-        - match: =
-          scope: punctuation.separator.key-value.html
-          set:
-            - meta_content_scope: meta.tag.script.begin.html meta.attribute-with-value.html
-            - include: script-type-decider
-        - match: (?=\S)
-          set: script-javascript
-
-  script-type-decider:
-    - match: (?i)(?={{javascript_mime_type}}(?!{{unquoted_attribute_value}})|'{{javascript_mime_type}}'|"{{javascript_mime_type}}")
-      set:
         - script-javascript
         - tag-generic-attribute-meta
         - tag-generic-attribute-value
-    - match: (?i)(?=module(?!{{unquoted_attribute_value}})|'module'|"module")
-      set:
-        - script-javascript
-        - tag-generic-attribute-meta
-        - tag-generic-attribute-value
-    - match: (?i)(?=>|''|"")
-      set:
-        - script-javascript
-        - tag-generic-attribute-meta
-        - tag-generic-attribute-value
-    - match: (?i)(?=text/html(?!{{unquoted_attribute_value}})|'text/html'|"text/html")
-      set:
-        - script-html
-        - tag-generic-attribute-meta
-        - tag-generic-attribute-value
-    - match: (?=\S)
-      set:
-        - script-other
-        - tag-generic-attribute-meta
-        - tag-generic-attribute-value
-
-  string-double-quoted:
-    - match: '"'
-      scope: punctuation.definition.string.begin.html
-      push:
-        - meta_scope: string.quoted.double.html
-        - match: '"'
-          scope: punctuation.definition.string.end.html
-          pop: true
-        - include: entities
-  string-single-quoted:
-    - match: "'"
-      scope: punctuation.definition.string.begin.html
-      push:
-        - meta_scope: string.quoted.single.html
-        - match: "'"
-          scope: punctuation.definition.string.end.html
-          pop: true
-        - include: entities
-
-  tag-generic-attribute:
-    - match: (?={{attribute_char}})
-      scope: entity.other.attribute-name.html
-      push:
-        - tag-generic-attribute-meta
-        - tag-generic-attribute-equals
-        - generic-attribute-name
-
-  generic-attribute-name:
-    - meta_scope: entity.other.attribute-name.html
-    - match: (?!{{attribute_char}})
-      pop: true
-
-  tag-generic-attribute-meta:
-    - meta_scope: meta.attribute-with-value.html
-    - include: immediately-pop
-
-  tag-generic-attribute-equals:
-    - match: '='
-      scope: punctuation.separator.key-value.html
-      set: tag-generic-attribute-value
-    - match: '{{not_equals_lookahead}}'
-      pop: true
-
-  tag-generic-attribute-value:
-    - match: '"'
-      scope: punctuation.definition.string.begin.html
-      set:
-        - meta_scope: string.quoted.double.html
-        - match: '"'
-          scope: punctuation.definition.string.end.html
-          pop: true
-        - include: entities
-    - match: "'"
-      scope: punctuation.definition.string.begin.html
-      set:
-        - meta_scope: string.quoted.single.html
-        - match: "'"
-          scope: punctuation.definition.string.end.html
-          pop: true
-        - include: entities
-    - match: '{{unquoted_attribute_value}}'
-      scope: string.unquoted.html
-      pop: true
-    - include: else-pop
-
-  tag-class-attribute:
-    - match: \bclass\b
-      scope: entity.other.attribute-name.class.html
-      push:
-        - tag-class-attribute-meta
-        - tag-class-attribute-equals
-
-  tag-class-attribute-meta:
-    - meta_scope: meta.attribute-with-value.class.html
-    - include: immediately-pop
-
-  tag-class-attribute-equals:
-    - match: '='
-      scope: punctuation.separator.key-value.html
-      set: tag-class-attribute-value
-    - match: '{{not_equals_lookahead}}'
-      pop: true
-
-  tag-class-attribute-value:
-    - match: '"'
-      scope: punctuation.definition.string.begin.html
-      set:
-        - meta_scope: string.quoted.double.html
-        - meta_content_scope: meta.class-name.html
-        - match: '"'
-          scope: punctuation.definition.string.end.html
-          pop: true
-        - include: entities
-    - match: "'"
-      scope: punctuation.definition.string.begin.html
-      set:
-        - meta_scope: string.quoted.single.html
-        - meta_content_scope: meta.class-name.html
-        - match: "'"
-          scope: punctuation.definition.string.end.html
-          pop: true
-        - include: entities
-    - match: '{{unquoted_attribute_value}}'
-      scope: string.unquoted.html meta.class-name.html
-      pop: true
-    - include: else-pop
-
-  tag-id-attribute:
-    - match: \bid\b
-      scope: entity.other.attribute-name.id.html
-      push:
-        - tag-id-attribute-meta
-        - tag-id-attribute-equals
 
   tag-id-attribute-meta:
     - meta_scope: meta.attribute-with-value.id.html
     - include: immediately-pop
-
-  tag-id-attribute-equals:
-    - match: '='
-      scope: punctuation.separator.key-value.html
-      set: tag-id-attribute-value
-    - match: '{{not_equals_lookahead}}'
-      pop: true
-
-  tag-id-attribute-value:
-    - match: '"'
-      scope: punctuation.definition.string.begin.html
-      set:
-        - meta_scope: string.quoted.double.html
-        - meta_content_scope: meta.toc-list.id.html
-        - match: '"'
-          scope: punctuation.definition.string.end.html
-          pop: true
-        - include: entities
-    - match: "'"
-      scope: punctuation.definition.string.begin.html
-      set:
-        - meta_scope: string.quoted.single.html
-        - meta_content_scope: meta.toc-list.id.html
-        - match: "'"
-          scope: punctuation.definition.string.end.html
-          pop: true
-        - include: entities
-    - match: '{{unquoted_attribute_value}}'
-      scope: string.unquoted.html meta.toc-list.id.html
-      pop: true
-    - include: else-pop
-
-  tag-style-attribute:
-    - match: \bstyle\b
-      scope: entity.other.attribute-name.style.html
-      push:
-        - tag-style-attribute-meta
-        - tag-style-attribute-equals
-
-  tag-style-attribute-meta:
-    - meta_scope: meta.attribute-with-value.style.html
-    - include: immediately-pop
-
-  tag-style-attribute-equals:
-    - match: '='
-      scope: punctuation.separator.key-value.html
-      set: tag-style-attribute-value
-    - match: '{{not_equals_lookahead}}'
-      pop: true
-
-  tag-style-attribute-value:
-    - match: '"'
-      scope: string.quoted.double punctuation.definition.string.begin.html
-      embed: scope:source.css#rule-list-body
-      embed_scope: source.css
-      escape: '"'
-      escape_captures:
-        0: string.quoted.double punctuation.definition.string.end.html
-    - match: "'"
-      scope: string.quoted.single punctuation.definition.string.begin.html
-      embed: scope:source.css#rule-list-body
-      embed_scope: source.css
-      escape: "'"
-      escape_captures:
-        0: string.quoted.single punctuation.definition.string.end.html
-    - include: else-pop
-
-  tag-event-attribute:
-    - match: |-
-        (?x)\bon(
-          abort|autocomplete|autocompleteerror|auxclick|blur|cancel|canplay
-          |canplaythrough|change|click|close|contextmenu|cuechange|dblclick|drag
-          |dragend|dragenter|dragexit|dragleave|dragover|dragstart|drop
-          |durationchange|emptied|ended|error|focus|input|invalid|keydown
-          |keypress|keyup|load|loadeddata|loadedmetadata|loadstart|mousedown
-          |mouseenter|mouseleave|mousemove|mouseout|mouseover|mouseup|mousewheel
-          |pause|play|playing|progress|ratechange|reset|resize|scroll|seeked
-          |seeking|select|show|sort|stalled|submit|suspend|timeupdate|toggle
-          |volumechange|waiting
-        )\b
-      scope: entity.other.attribute-name.event.html
-      push:
-        - tag-event-attribute-meta
-        - tag-event-attribute-equals
-
-  tag-event-attribute-meta:
-    - meta_scope: meta.attribute-with-value.event.html
-    - include: immediately-pop
-
-  tag-event-attribute-equals:
-    - match: '='
-      scope: punctuation.separator.key-value.html
-      set: tag-event-attribute-value
-    - match: '{{not_equals_lookahead}}'
-      pop: true
-
-  tag-event-attribute-value:
-    - match: '"'
-      scope: string.quoted.double punctuation.definition.string.begin.html
-      embed: scope:source.js
-      embed_scope: meta.attribute-with-value.event.html
-      escape: '"'
-      escape_captures:
-        0: string.quoted.double punctuation.definition.string.end.html
-    - match: "'"
-      scope: string.quoted.single punctuation.definition.string.begin.html meta.attribute-with-value.event.html
-      embed: scope:source.js
-      embed_scope: meta.attribute-with-value.event.html
-      escape: "'"
-      escape_captures:
-        0: string.quoted.single punctuation.definition.string.end.html
-    - include: else-pop
-
-  # This is to prevent breaking syntaxes referencing the old context name
-  tag-stuff:
-    - include: tag-attributes
 
   tag-attributes:
     - include: vue-directive
@@ -637,74 +517,14 @@ contexts:
     - include: tag-style-attribute
     - include: tag-event-attribute
     - include: tag-generic-attribute
-  mustache-expression:
-    - match: (?={{)
-      set:
-        - meta_scope: meta.template.vue
-        - match: '{{'
-          scope: punctuation.definition.template.begin.html
-          embed: scope:source.js
-          embed_scope: source.js.embedded.vue
-          escape: '}}'
-          escape_captures:
-            0: meta.template.vue punctuation.definition.template.end.html
-        - match: ''
-          pop: true
-
-  template-tag:
-    - match: (<)((?i:template(>| )))\b
+  style-close-tag:
+    - match: (?i)(</)(style)(>)
+      scope: meta.tag.style.end.html
       captures:
-        0: meta.tag.template.begin.html
         1: punctuation.definition.tag.begin.html
-        2: entity.name.tag.template.html
-      push: template-mustache
-
-  vue-directive:
-    - match: \b(v-[\w\:\.-]+)\b
-      scope: entity.other.attribute-name.html
-      push: js-attribute-value
-    - match: \B(:|@)([\w\.-]+)\b
-      captures:
-        1: punctuation.definition.attribute.html
-        2: entity.other.attribute-name.html
-      push: js-attribute-value
-
-  js-attribute-value:
-    - match: '='
-      scope: punctuation.separator.key-value.html
-      set: js-string
-    - include: else-pop
-
-  js-string:
-    - match: '"'
-      scope: punctuation.definition.string.begin.html
-      embed: scope:source.js
-      embed_scope: source.js.embedded.vue
-      escape: '"'
-      escape_captures:
-        0: punctuation.definition.string.end.html
-    - match: "'"
-      scope: punctuation.definition.string.begin.html
-      embed: scope:source.js
-      embed_scope: source.js.embedded.vue
-      escape: "'"
-      escape_captures:
-        0: punctuation.definition.string.end.html
-
-    - include: else-pop
-
-  style-lang-attribute:
-    - match: (?i)\blang\b
-      scope: meta.attribute-with-value.html entity.other.attribute-name.html
-      set:
-        - meta_content_scope: meta.tag.style.begin.html meta.attribute-with-value.html
-        - match: =
-          scope: punctuation.separator.key-value.html
-          set:
-            - meta_content_scope: meta.tag.style.begin.html meta.attribute-with-value.html
-            - include: style-lang-decider
-        - match: (?=\S)
-          set: style-css
+        2: entity.name.tag.style.html
+        3: punctuation.definition.tag.end.html
+      pop: true
 
   style-lang-decider:
     - match: (?i)(?=sass(?!{{unquoted_attribute_value}})|\'sass\'|"sass")
@@ -797,83 +617,92 @@ contexts:
         - tag-generic-attribute-meta
         - tag-generic-attribute-value
 
-  script-lang-attribute:
-    - match: (?i)\blang\b
-      scope: meta.attribute-with-value.html entity.other.attribute-name.html
-      set:
-        - meta_content_scope: meta.tag.script.begin.html meta.attribute-with-value.html
-        - match: =
-          scope: punctuation.separator.key-value.html
-          set:
-            - meta_content_scope: meta.tag.script.begin.html meta.attribute-with-value.html
-            - include: script-lang-decider
-        - match: (?=\S)
-          set: script-javascript
+  string-double-quoted:
+    - match: '"'
+      scope: punctuation.definition.string.begin.html
+      push:
+        - meta_scope: string.quoted.double.html
+        - match: '"'
+          scope: punctuation.definition.string.end.html
+          pop: true
+        - include: entities
+  tag-class-attribute-equals:
+    - match: '='
+      scope: punctuation.separator.key-value.html
+      set: tag-class-attribute-value
+    - match: '{{not_equals_lookahead}}'
+      pop: true
 
-  script-lang-decider:
-    - match: (?i)(?=coffee(?!{{unquoted_attribute_value}})|\'coffee\'|"coffee")
-      set:
-        -   - meta_content_scope: meta.tag.script.begin.html
-            - include: script-common
-            - match: '>'
-              scope: punctuation.definition.tag.end.html
-              set:
-                - include: script-close-tag
-                - embed_scope: source.coffee.embedded.html
-                  match: ''
-                  embed: scope:source.coffee
-                  escape: (?i)(?=(?:-->\s*)?</script)
-        - tag-generic-attribute-meta
-        - tag-generic-attribute-value
-    - match: (?i)(?=livescript(?!{{unquoted_attribute_value}})|\'livescript\'|"livescript")
-      set:
-        -   - meta_content_scope: meta.tag.script.begin.html
-            - include: script-common
-            - match: '>'
-              scope: punctuation.definition.tag.end.html
-              set:
-                - include: script-close-tag
-                - embed_scope: source.livescript.embedded.html
-                  match: ''
-                  embed: scope:source.livescript
-                  escape: (?i)(?=(?:-->\s*)?</script)
-        - tag-generic-attribute-meta
-        - tag-generic-attribute-value
-    - match: (?i)(?=ts(?!{{unquoted_attribute_value}})|\'ts\'|"ts")
-      set:
-        -   - meta_content_scope: meta.tag.script.begin.html
-            - include: script-common
-            - match: '>'
-              scope: punctuation.definition.tag.end.html
-              set:
-                - include: script-close-tag
-                - embed_scope: source.ts.embedded.html
-                  match: ''
-                  embed: scope:source.ts
-                  escape: (?i)(?=(?:-->\s*)?</script)
-        - tag-generic-attribute-meta
-        - tag-generic-attribute-value
-    - match: (?=\S)
-      set:
-        - script-javascript
-        - tag-generic-attribute-meta
-        - tag-generic-attribute-value
+  tag-generic-attribute-meta:
+    - meta_scope: meta.attribute-with-value.html
+    - include: immediately-pop
 
-  template-common:
-    - include: template-lang-attribute
+  tag-class-attribute-value:
+    - match: '"'
+      scope: punctuation.definition.string.begin.html
+      set:
+        - meta_scope: string.quoted.double.html
+        - meta_content_scope: meta.class-name.html
+        - match: '"'
+          scope: punctuation.definition.string.end.html
+          pop: true
+        - include: entities
+    - match: "'"
+      scope: punctuation.definition.string.begin.html
+      set:
+        - meta_scope: string.quoted.single.html
+        - meta_content_scope: meta.class-name.html
+        - match: "'"
+          scope: punctuation.definition.string.end.html
+          pop: true
+        - include: entities
+    - match: '{{unquoted_attribute_value}}'
+      scope: string.unquoted.html meta.class-name.html
+      pop: true
+    - include: else-pop
+
+  style-common:
+    - include: style-lang-attribute
+
+    - include: style-type-attribute
     - include: tag-attributes
     - match: />
       scope: punctuation.definition.tag.end.html
       pop: true
 
-  template-close-tag:
-    - match: (?i)(</)(template)(>)
-      scope: meta.tag.template.end.html
-      captures:
-        1: punctuation.definition.tag.begin.html
-        2: entity.name.tag.template.html
-        3: punctuation.definition.tag.end.html
+  tag-generic-attribute-equals:
+    - match: '='
+      scope: punctuation.separator.key-value.html
+      set: tag-generic-attribute-value
+    - match: '{{not_equals_lookahead}}'
       pop: true
+
+  script-type-decider:
+    - match: (?i)(?={{javascript_mime_type}}(?!{{unquoted_attribute_value}})|'{{javascript_mime_type}}'|"{{javascript_mime_type}}")
+      set:
+        - script-javascript
+        - tag-generic-attribute-meta
+        - tag-generic-attribute-value
+    - match: (?i)(?=module(?!{{unquoted_attribute_value}})|'module'|"module")
+      set:
+        - script-javascript
+        - tag-generic-attribute-meta
+        - tag-generic-attribute-value
+    - match: (?i)(?=>|''|"")
+      set:
+        - script-javascript
+        - tag-generic-attribute-meta
+        - tag-generic-attribute-value
+    - match: (?i)(?=text/html(?!{{unquoted_attribute_value}})|'text/html'|"text/html")
+      set:
+        - script-html
+        - tag-generic-attribute-meta
+        - tag-generic-attribute-value
+    - match: (?=\S)
+      set:
+        - script-other
+        - tag-generic-attribute-meta
+        - tag-generic-attribute-value
 
   template-mustache:
     - meta_content_scope: meta.tag.template.begin.html
@@ -885,18 +714,41 @@ contexts:
         - match: ''
           push: main
 
-  template-lang-attribute:
-    - match: (?i)\blang\b
+  tag-class-attribute-meta:
+    - meta_scope: meta.attribute-with-value.class.html
+    - include: immediately-pop
+
+  style-type-attribute:
+    - match: (?i)\btype\b
       scope: meta.attribute-with-value.html entity.other.attribute-name.html
       set:
-        - meta_content_scope: meta.tag.template.begin.html meta.attribute-with-value.html
+        - meta_content_scope: meta.tag.style.begin.html meta.attribute-with-value.html
         - match: =
           scope: punctuation.separator.key-value.html
           set:
-            - meta_content_scope: meta.tag.template.begin.html meta.attribute-with-value.html
-            - include: template-lang-decider
+            - meta_content_scope: meta.tag.style.begin.html meta.attribute-with-value.html
+            - include: style-type-decider
         - match: (?=\S)
-          set: template-mustache
+          set: style-css
+
+  template-tag:
+    - match: (<)((?i:template(>| )))\b
+      captures:
+        0: meta.tag.template.begin.html
+        1: punctuation.definition.tag.begin.html
+        2: entity.name.tag.template.html
+      push: template-mustache
+
+  tag-stuff:
+    - include: tag-attributes
+
+  tag-generic-attribute:
+    - match: (?={{attribute_char}})
+      scope: entity.other.attribute-name.html
+      push:
+        - tag-generic-attribute-meta
+        - tag-generic-attribute-equals
+        - generic-attribute-name
 
   template-lang-decider:
     - match: (?i)(?=jade(?!{{unquoted_attribute_value}})|\'jade\'|"jade")
@@ -946,4 +798,174 @@ contexts:
         - template-mustache
         - tag-generic-attribute-meta
         - tag-generic-attribute-value
-hidden: false
+  tag-event-attribute-meta:
+    - meta_scope: meta.attribute-with-value.event.html
+    - include: immediately-pop
+
+  js-string:
+    - match: '"'
+      scope: punctuation.definition.string.begin.html
+      embed: scope:source.js
+      embed_scope: source.js.embedded.vue
+      escape: '"'
+      escape_captures:
+        0: punctuation.definition.string.end.html
+    - match: "'"
+      scope: punctuation.definition.string.begin.html
+      embed: scope:source.js
+      embed_scope: source.js.embedded.vue
+      escape: "'"
+      escape_captures:
+        0: punctuation.definition.string.end.html
+
+    - include: else-pop
+
+  query-tag:
+    - match: (<)(page-query|static-query)(>)
+      captures:
+        1: punctuation.definition.tag.begin.html
+        2: entity.name.tag.block.any.html
+        3: punctuation.definition.tag.end.html
+      embed: scope:source.graphql
+      embed_scope: source.graphql
+      escape: (</?)(page-query|static-query)(>)
+      escape_captures:
+        1: punctuation.definition.tag.begin.html
+        2: entity.name.tag.block.any.html
+        3: punctuation.definition.tag.end.html
+    # - match: (</?)(page-query|static-query)(>)
+    #   captures:
+    #     1: punctuation.definition.tag.begin.html
+    #     2: entity.name.tag.block.any.html
+    #     3: punctuation.definition.tag.end.html
+    #   pop: true
+
+  style-lang-attribute:
+    - match: (?i)\blang\b
+      scope: meta.attribute-with-value.html entity.other.attribute-name.html
+      set:
+        - meta_content_scope: meta.tag.style.begin.html meta.attribute-with-value.html
+        - match: =
+          scope: punctuation.separator.key-value.html
+          set:
+            - meta_content_scope: meta.tag.style.begin.html meta.attribute-with-value.html
+            - include: style-lang-decider
+        - match: (?=\S)
+          set: style-css
+
+  tag-event-attribute-value:
+    - match: '"'
+      scope: string.quoted.double punctuation.definition.string.begin.html
+      embed: scope:source.js
+      embed_scope: meta.attribute-with-value.event.html
+      escape: '"'
+      escape_captures:
+        0: string.quoted.double punctuation.definition.string.end.html
+    - match: "'"
+      scope: string.quoted.single punctuation.definition.string.begin.html meta.attribute-with-value.event.html
+      embed: scope:source.js
+      embed_scope: meta.attribute-with-value.event.html
+      escape: "'"
+      escape_captures:
+        0: string.quoted.single punctuation.definition.string.end.html
+    - include: else-pop
+
+  # This is to prevent breaking syntaxes referencing the old context name
+  style-css:
+    - meta_content_scope: meta.tag.style.begin.html
+    - include: style-common
+    - match: '>'
+      scope: punctuation.definition.tag.end.html
+      set:
+        - include: style-close-tag
+        - match: ''
+          embed: scope:source.css
+          embed_scope: source.css.embedded.html
+          escape: (?i)(?=(?:-->\s*)?</style)
+
+  template-close-tag:
+    - match: (?i)(</)(template)(>)
+      scope: meta.tag.template.end.html
+      captures:
+        1: punctuation.definition.tag.begin.html
+        2: entity.name.tag.template.html
+        3: punctuation.definition.tag.end.html
+      pop: true
+
+  script-close-tag:
+    - match: \s*(<!--)
+      captures:
+        1: comment.block.html punctuation.definition.comment.begin.html
+    - match: (?i)(?:(-->)\s*)?(</)(script)(>)
+      scope: meta.tag.script.end.html
+      captures:
+        1: comment.block.html punctuation.definition.comment.end.html
+        2: punctuation.definition.tag.begin.html
+        3: entity.name.tag.script.html
+        4: punctuation.definition.tag.end.html
+      pop: true
+
+  template-lang-attribute:
+    - match: (?i)\blang\b
+      scope: meta.attribute-with-value.html entity.other.attribute-name.html
+      set:
+        - meta_content_scope: meta.tag.template.begin.html meta.attribute-with-value.html
+        - match: =
+          scope: punctuation.separator.key-value.html
+          set:
+            - meta_content_scope: meta.tag.template.begin.html meta.attribute-with-value.html
+            - include: template-lang-decider
+        - match: (?=\S)
+          set: template-mustache
+
+  script-javascript:
+    - meta_content_scope: meta.tag.script.begin.html
+    - include: script-common
+    - match: '>'
+      scope: punctuation.definition.tag.end.html
+      set:
+        - include: script-close-tag
+        - match: (?=\S)
+          embed: scope:source.js
+          embed_scope: source.js.embedded.html
+          escape: (?i)(?=(?:-->\s*)?</script)
+
+  style-other:
+    - meta_content_scope: meta.tag.style.begin.html
+    - include: style-common
+    - match: '>'
+      scope: punctuation.definition.tag.end.html
+      set:
+        - include: style-close-tag
+
+  script-common:
+    - include: script-lang-attribute
+
+    - include: script-type-attribute
+    - include: tag-attributes
+    - match: />
+      scope: punctuation.definition.tag.end.html
+      pop: true
+
+  string-single-quoted:
+    - match: "'"
+      scope: punctuation.definition.string.begin.html
+      push:
+        - meta_scope: string.quoted.single.html
+        - match: "'"
+          scope: punctuation.definition.string.end.html
+          pop: true
+        - include: entities
+
+  tag-style-attribute:
+    - match: \bstyle\b
+      scope: entity.other.attribute-name.style.html
+      push:
+        - tag-style-attribute-meta
+        - tag-style-attribute-equals
+
+  immediately-pop:
+    - match: ''
+      pop: true
+
+name: Vue Component

--- a/Vue Component.sublime-syntax.yaml-macros
+++ b/Vue Component.sublime-syntax.yaml-macros
@@ -12,6 +12,7 @@ contexts: !merge
   main: !prepend
     - include: template-tag
     - include: mustache-expression
+    - include: query-tag
 
   mustache-expression:
     - match: '(?={{)'
@@ -37,6 +38,20 @@ contexts: !merge
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.template.html
       push: template-mustache
+
+  query-tag:
+    - match: (<)(page-query|static-query)(>)
+      captures:
+        1: punctuation.definition.tag.begin.html
+        2: entity.name.tag.block.any.html
+        3: punctuation.definition.tag.end.html
+      embed: scope:source.graphql
+      embed_scope: source.graphql
+      escape: (</?)(page-query|static-query)(>)
+      escape_captures:
+        1: punctuation.definition.tag.begin.html
+        2: entity.name.tag.block.any.html
+        3: punctuation.definition.tag.end.html
 
   vue-directive:
     - match: \b(v-[\w\:\.-]+)\b

--- a/samples/graphql.vue
+++ b/samples/graphql.vue
@@ -1,0 +1,10 @@
+<page-query>
+  query Article($id: String!) {
+    contentfulCaseStudy(id: $id) {
+      id
+      title
+      slug
+      content(html: true)
+    }
+  }
+</page-query>


### PR DESCRIPTION
- `query-tag` deals with embedded GraphQL syntax inside `<page-query>` and `<static-query>` blocks
- add file containing GraphQL code sample
- recompile master syntax file

Close #200

**Looking for feedback on this, as I'm new to `.sublime-syntax` and not a regex expert.**