### PR TITLE
Adding syntax highlighting for template tags with `lang="haml"`

### DIFF
--- a/vue.tmLanguage
+++ b/vue.tmLanguage
@@ -211,6 +211,60 @@
 		</dict>
 		<dict>
 			<key>begin</key>
+			<string>(?:^\s+)?(&lt;)((?i:template))\b(?=[^&gt;]*lang=(['"])haml\1?)</string>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.tag.begin.html</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>entity.name.tag.style.html</string>
+				</dict>
+				<key>3</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.tag.html</string>
+				</dict>
+			</dict>
+			<key>end</key>
+			<string>(&lt;/)((?i:template))(&gt;)(?:\s*\n)?</string>
+			<key>name</key>
+			<string>text.haml.embedded.html</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>#tag-stuff</string>
+				</dict>
+				<dict>
+					<key>begin</key>
+					<string>(&gt;)</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.tag.end.html</string>
+						</dict>
+					</dict>
+					<key>end</key>
+					<string>(?=&lt;/(?i:template))</string>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>include</key>
+							<string>text.haml</string>
+						</dict>
+					</array>
+				</dict>
+			</array>
+		</dict>
+		<dict>
+			<key>begin</key>
 			<string>(?:^\s+)?(&lt;)((?i:template))\b(?=[^&gt;]*lang=(['"])slm\1?)</string>
 			<key>captures</key>
 			<dict>


### PR DESCRIPTION
Adding syntax highlighting for template tags with `lang="haml"`

```
<template lang="haml">
  .hello-world
    %strong Hello
    world!
</template>
```

<img width="753" alt="Bildschirmfoto 2020-07-26 um 13 58 43" src="https://user-images.githubusercontent.com/1679688/88478390-1f6c2f00-cf48-11ea-9080-10276adbb3d3.png">
