### PR TITLE
Better v-on '@' shorthand match

### DIFF
--- a/Vue Component.sublime-syntax
+++ b/Vue Component.sublime-syntax
@@ -663,7 +663,7 @@ contexts:
     - match: \b(v-[\w\:\.-]+)\b
       scope: entity.other.attribute-name.html
       push: js-attribute-value
-    - match: \B(:|@)([\w\.-]+)\b
+    - match: \B(:|@)([\w\:\.-]+)\b
       captures:
         1: punctuation.definition.attribute.html
         2: entity.other.attribute-name.html

--- a/Vue Component.sublime-syntax.yaml-macros
+++ b/Vue Component.sublime-syntax.yaml-macros
@@ -42,7 +42,7 @@ contexts: !merge
     - match: \b(v-[\w\:\.-]+)\b
       scope: entity.other.attribute-name.html
       push: js-attribute-value
-    - match: \B(:|@)([\w\.-]+)\b
+    - match: \B(:|@)([\w\:\.-]+)\b
       captures:
         1: punctuation.definition.attribute.html
         2: entity.other.attribute-name.html


### PR DESCRIPTION
Support v-on shorthand with event handlers containing colon (e.g. `@hook:mounted="onChildMounted"`)

I'm not 100% certain, but I think the matching should be the same as for regular `v-*` at line 663. Potentially fixes #203. Tested locally for that scenario, but I'm not sure if there are other directives which might be affected by this.