### PR TITLE
fix: use HTML Living Standard comment syntax

### DIFF
--- a/vue.YAML-tmLanguage
+++ b/vue.YAML-tmLanguage
@@ -36,12 +36,9 @@ patterns:
 
 - name: comment.block.html
   begin: <!--
-  end: --\s*>
+  end: -->
   captures:
     '0': {name: punctuation.definition.comment.html}
-  patterns:
-  - name: invalid.illegal.bad-comments-or-CDATA.html
-    match: --
 
 - name: meta.tag.sgml.html
   begin: <!
@@ -465,7 +462,7 @@ repository:
 foldingStartMarker: |-
   (?x)
   (<(?i:head|body|table|thead|tbody|tfoot|tr|div|select|fieldset|style|script|ul|ol|li|form|dl)\b.*?>
-  |<!--(?!.*--\s*>)
+  |<!--(?!.*-->)
   |^<!--\ \#tminclude\ (?>.*?-->)$
   |<\?(?:php)?.*\b(if|for(each)?|while)\b.+:
   |\{\{?(if|foreach|capture|literal|foreach|php|section|strip)
@@ -475,7 +472,7 @@ foldingStartMarker: |-
 foldingStopMarker: |-
   (?x)
   (</(?i:head|body|table|thead|tbody|tfoot|tr|div|select|fieldset|style|script|ul|ol|li|form|dl)>
-  |^(?!.*?<!--).*?--\s*>
+  |^(?!.*?<!--).*?-->
   |^<!--\ end\ tminclude\ -->$
   |<\?(?:php)?.*\bend(if|for(each)?|while)\b
   |\{\{?/(if|foreach|capture|literal|foreach|php|section|strip)

--- a/vue.tmLanguage
+++ b/vue.tmLanguage
@@ -9,7 +9,7 @@
 	<key>foldingStartMarker</key>
 	<string>(?x)
 (&lt;(?i:head|body|table|thead|tbody|tfoot|tr|div|select|fieldset|style|script|ul|ol|li|form|dl)\b.*?&gt;
-|&lt;!--(?!.*--\s*&gt;)
+|&lt;!--(?!.*--&gt;)
 |^&lt;!--\ \#tminclude\ (?&gt;.*?--&gt;)$
 |&lt;\?(?:php)?.*\b(if|for(each)?|while)\b.+:
 |\{\{?(if|foreach|capture|literal|foreach|php|section|strip)
@@ -18,7 +18,7 @@
 	<key>foldingStopMarker</key>
 	<string>(?x)
 (&lt;/(?i:head|body|table|thead|tbody|tfoot|tr|div|select|fieldset|style|script|ul|ol|li|form|dl)&gt;
-|^(?!.*?&lt;!--).*?--\s*&gt;
+|^(?!.*?&lt;!--).*?--&gt;
 |^&lt;!--\ end\ tminclude\ --&gt;$
 |&lt;\?(?:php)?.*\bend(if|for(each)?|while)\b
 |\{\{?/(if|foreach|capture|literal|foreach|php|section|strip)
@@ -138,18 +138,9 @@
 				</dict>
 			</dict>
 			<key>end</key>
-			<string>--\s*&gt;</string>
+			<string>--&gt;</string>
 			<key>name</key>
 			<string>comment.block.html</string>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>match</key>
-					<string>--</string>
-					<key>name</key>
-					<string>invalid.illegal.bad-comments-or-CDATA.html</string>
-				</dict>
-			</array>
 		</dict>
 		<dict>
 			<key>begin</key>


### PR DESCRIPTION
Currently, double-hyphens (`--`) inside comments aren't allowed in the linguist syntax highlight. However, the parser allows them without any warnings.

The SFC Spec says ["use HTML comment syntax"](https://vue-loader.vuejs.org/spec.html#comments) but *HTML comment syntax* definition is little ambiguous. [HTML Living Standard allows to use double-hyphens inside](https://html.spec.whatwg.org/multipage/syntax.html#comments), however, contrarily [HTML 4.01 and past forbid it](https://www.w3.org/TR/html401/intro/sgmltut.html#h-3.2.4). Current vue-syntax-highlight seems refering the latter spec, but [the actual parser implementation follows the former spec](https://github.com/vuejs/vue/blob/8f6f1d355c6d6b0916e7669dddad4e326eade367/src/compiler/parser/html-parser.js#L67-L78).

This change adjusts vue-syntax-highlight definitions to vue's compiler/parser/html-parser behavior.