### PR TITLE
Fix compatibility with new ST4 versions

### DIFF
--- a/Vue Component.sublime-syntax
+++ b/Vue Component.sublime-syntax
@@ -102,8 +102,8 @@ contexts:
               scope: punctuation.definition.tag.end.html
               set:
                 - include: style-close-tag
-                - embed_scope: source.sass.embedded.html
-                  match: ''
+                - match: ''
+                  embed_scope: source.sass.embedded.html
                   embed: scope:source.sass
                   escape: (?i)(?=(?:-->\s*)?</style{{tag_name_break_char}})
         - tag-generic-attribute-meta
@@ -116,8 +116,8 @@ contexts:
               scope: punctuation.definition.tag.end.html
               set:
                 - include: style-close-tag
-                - embed_scope: source.scss.embedded.html
-                  match: ''
+                - match: ''
+                  embed_scope: source.scss.embedded.html
                   embed: scope:source.scss
                   escape: (?i)(?=(?:-->\s*)?</style{{tag_name_break_char}})
         - tag-generic-attribute-meta
@@ -130,8 +130,8 @@ contexts:
               scope: punctuation.definition.tag.end.html
               set:
                 - include: style-close-tag
-                - embed_scope: source.stylus.embedded.html
-                  match: ''
+                - match: ''
+                  embed_scope: source.stylus.embedded.html
                   embed: scope:source.stylus
                   escape: (?i)(?=(?:-->\s*)?</style{{tag_name_break_char}})
         - tag-generic-attribute-meta
@@ -144,8 +144,8 @@ contexts:
               scope: punctuation.definition.tag.end.html
               set:
                 - include: style-close-tag
-                - embed_scope: source.sss.embedded.html
-                  match: ''
+                - match: ''
+                  embed_scope: source.sss.embedded.html
                   embed: scope:source.sss
                   escape: (?i)(?=(?:-->\s*)?</style{{tag_name_break_char}})
         - tag-generic-attribute-meta
@@ -158,8 +158,8 @@ contexts:
               scope: punctuation.definition.tag.end.html
               set:
                 - include: style-close-tag
-                - embed_scope: source.postcss.embedded.html
-                  match: ''
+                - match: ''
+                  embed_scope: source.postcss.embedded.html
                   embed: scope:source.postcss
                   escape: (?i)(?=(?:-->\s*)?</style{{tag_name_break_char}})
         - tag-generic-attribute-meta
@@ -172,8 +172,8 @@ contexts:
               scope: punctuation.definition.tag.end.html
               set:
                 - include: style-close-tag
-                - embed_scope: source.less.embedded.html
-                  match: ''
+                - match: ''
+                  embed_scope: source.less.embedded.html
                   embed: scope:source.less
                   escape: (?i)(?=(?:-->\s*)?</style{{tag_name_break_char}})
         - tag-generic-attribute-meta
@@ -187,12 +187,6 @@ contexts:
   script-common:
     - meta_prepend: true
     - include: script-lang-attribute
-
-  script-javascript-content:
-    - match: (?=\S)
-      embed: scope:source.js
-      embed_scope: source.js.embedded.html
-      escape: '{{script_close_lookahead}}'
 
   script-lang-attribute:
     - match: (?i:lang){{attribute_name_break}}
@@ -216,8 +210,8 @@ contexts:
               scope: punctuation.definition.tag.end.html
               set:
                 - include: script-close-tag
-                - embed_scope: source.coffee.embedded.html
-                  match: ''
+                - match: ''
+                  embed_scope: source.coffee.embedded.html
                   embed: scope:source.coffee
                   escape: (?i)(?=(?:-->\s*)?</script{{tag_name_break_char}})
         - tag-generic-attribute-meta
@@ -230,8 +224,8 @@ contexts:
               scope: punctuation.definition.tag.end.html
               set:
                 - include: script-close-tag
-                - embed_scope: source.livescript.embedded.html
-                  match: ''
+                - match: ''
+                  embed_scope: source.livescript.embedded.html
                   embed: scope:source.livescript
                   escape: (?i)(?=(?:-->\s*)?</script{{tag_name_break_char}})
         - tag-generic-attribute-meta
@@ -244,8 +238,8 @@ contexts:
               scope: punctuation.definition.tag.end.html
               set:
                 - include: script-close-tag
-                - embed_scope: source.ts.embedded.html
-                  match: ''
+                - match: ''
+                  embed_scope: source.ts.embedded.html
                   embed: scope:source.ts
                   escape: (?i)(?=(?:-->\s*)?</script{{tag_name_break_char}})
         - tag-generic-attribute-meta
@@ -304,8 +298,8 @@ contexts:
               scope: punctuation.definition.tag.end.html
               set:
                 - include: template-close-tag
-                - embed_scope: text.jade.embedded.html
-                  match: ''
+                - match: ''
+                  embed_scope: text.jade.embedded.html
                   embed: scope:text.jade
                   escape: (?i)(?=(?:-->\s*)?</template{{tag_name_break_char}})
         - tag-generic-attribute-meta
@@ -318,8 +312,8 @@ contexts:
               scope: punctuation.definition.tag.end.html
               set:
                 - include: template-close-tag
-                - embed_scope: text.pug.embedded.html
-                  match: ''
+                - match: ''
+                  embed_scope: text.pug.embedded.html
                   embed: scope:text.pug
                   escape: (?i)(?=(?:-->\s*)?</template{{tag_name_break_char}})
         - tag-generic-attribute-meta
@@ -332,8 +326,8 @@ contexts:
               scope: punctuation.definition.tag.end.html
               set:
                 - include: template-close-tag
-                - embed_scope: text.slm.embedded.html
-                  match: ''
+                - match: ''
+                  embed_scope: text.slm.embedded.html
                   embed: scope:text.slm
                   escape: (?i)(?=(?:-->\s*)?</template{{tag_name_break_char}})
         - tag-generic-attribute-meta

--- a/Vue Component.sublime-syntax.yaml-macros
+++ b/Vue Component.sublime-syntax.yaml-macros
@@ -119,12 +119,6 @@ contexts:
     - meta_prepend: true
     - include: script-lang-attribute
 
-  script-javascript-content:
-    - match: (?=\S)
-      embed: scope:source.js
-      embed_scope: source.js.embedded.html
-      escape: '{{script_close_lookahead}}'
-
   script-lang-attribute:
     - match: (?i:lang){{attribute_name_break}}
       scope: meta.attribute-with-value.html entity.other.attribute-name.html


### PR DESCRIPTION
A non-backward compatible change was introduced in updated HTML syntax
that breaks loading of Vue syntax.

This removes context that references removed variable `script_close_lookahead`.
There is supposedly no point to overriding it in the first places since
there is no custom syntax introduced here.

Fixes #213

@skyronic @Thom1729 @deathaxe