### PR TITLE
Fix script highlighting for "text/babel"

### DIFF
--- a/Vue Component.sublime-syntax
+++ b/Vue Component.sublime-syntax
@@ -10,6 +10,26 @@ file_extensions:
   - vue
 
 variables:
+  javascript_mime_type: |-
+    (?xi:
+      (?:
+      # default JS MIME types
+      # https://mimesniff.spec.whatwg.org/#javascript-mime-type
+        (?:application|text)/(?:x-)?(?:java|ecma)script
+      | text/javascript1\.[0-5]
+      | text/jscript
+      | text/livescript
+      # non-standard JS MIME types
+      | text/babel
+      )
+      {{mime_type_parameters}}?
+    )
+
+  # A MIME type’s parameters is an ordered map whose keys are ASCII strings and values are strings
+  # limited to HTTP quoted-string token code points. It is initially empty.
+  # Note: for backward compatibility with ST <4135
+  mime_type_parameters: (?:;.*?)
+
   # Embedded script and style syntaxes may be wrapped into html comments for
   # historical reasons. The following patterns match them, while maintaining
   # correct boundaries of embedded source scopes. That's required to enable

--- a/Vue Component.sublime-syntax.yaml-macros
+++ b/Vue Component.sublime-syntax.yaml-macros
@@ -11,6 +11,26 @@ file_extensions:
   - vue
 
 variables:
+  javascript_mime_type: |-
+    (?xi:
+      (?:
+      # default JS MIME types
+      # https://mimesniff.spec.whatwg.org/#javascript-mime-type
+        (?:application|text)/(?:x-)?(?:java|ecma)script
+      | text/javascript1\.[0-5]
+      | text/jscript
+      | text/livescript
+      # non-standard JS MIME types
+      | text/babel
+      )
+      {{mime_type_parameters}}?
+    )
+
+  # A MIME type’s parameters is an ordered map whose keys are ASCII strings and values are strings
+  # limited to HTTP quoted-string token code points. It is initially empty.
+  # Note: for backward compatibility with ST <4135
+  mime_type_parameters: (?:;.*?)
+
   # Embedded script and style syntaxes may be wrapped into html comments for
   # historical reasons. The following patterns match them, while maintaining
   # correct boundaries of embedded source scopes. That's required to enable

--- a/tests/syntax_test_script.vue
+++ b/tests/syntax_test_script.vue
@@ -132,6 +132,10 @@
 // ^ source.js.embedded.html - source source
 //  ^^^^^^^^^ meta.tag - source
 
+    <script type="text/babel">var foo</script>
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.script.begin.html
+//                            ^^^^^^^ source.js.embedded.html
+//                                   ^^^^^^^^^ meta.tag.script.end.html
 
     <script lang="coffee">  </script>
 //  ^^^^^^^^^^^^^^^^^^^^^^ meta.tag - meta.tag meta.tag - source


### PR DESCRIPTION
Fixes #218

This commit copies `javascript_mime_type` variable from default HTML.sublime-syntax and adds `text/babel` to enable JavaScript highlighting of that non-standard MIME type.